### PR TITLE
Add read_to_string and read_json_struct functions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,24 @@
+name: Rust
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: cargo build
+      - name: Build no-default
+        run: cargo build --no-default-features
+      - name: Run tests
+        run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oneio"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 edition = "2021"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,12 @@ flate2 = {version = "1", optional=true }
 bzip2 = {version = "0.4", optional = true }
 lz4 = {version = "1.23", optional = true }
 clap = {version="3.2", features=["derive"], optional=true}
+serde = {version="1.0", optional=true }
+serde_json = {version="1.0", optional=true }
 
 [features]
 default = ["all"]
-all = ["remote", "gz", "bz", "lz", "bin"]
+all = ["lib_only", "bin"]
 lib_only = ["remote", "gz", "bz", "lz"]
 
 remote=["reqwest"]
@@ -38,3 +40,7 @@ gz = ["flate2"]
 bz = ["bzip2"]
 lz = ["lz4"]
 bin = ["clap"]
+json = ["serde", "serde_json"]
+
+[dev-dependencies]
+serde = {version="1.0", features=["derive"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ serde_json = {version="1.0", optional=true }
 [features]
 default = ["all"]
 all = ["lib_only", "bin"]
-lib_only = ["remote", "gz", "bz", "lz"]
+lib_only = ["remote", "gz", "bz", "lz", "json"]
 
 remote=["reqwest"]
 gz = ["flate2"]

--- a/src/bin/oneio.rs
+++ b/src/bin/oneio.rs
@@ -48,7 +48,7 @@ fn main() {
                     eprintln!("{} is not a remote file, skip downloading", path);
                     return
                 }
-                path.split("/").last().unwrap().to_string()
+                path.split('/').last().unwrap().to_string()
             }
             Some(p) => {
                 p.to_str().unwrap().to_string()
@@ -60,7 +60,7 @@ fn main() {
                 println!("file successfully downloaded to {}", out_path.as_str());
             }
             Err(e) => {
-                eprintln!("file download error: {}", e.to_string());
+                eprintln!("file download error: {}", e);
             }
         }
 
@@ -73,7 +73,7 @@ fn main() {
             match oneio::get_cache_reader(path, dir.as_str(), cli.cache_file, cli.cache_force) {
                 Ok(reader) => {reader}
                 Err(e) => {
-                    eprintln!("cannot open {}: {}", path, e.to_string());
+                    eprintln!("cannot open {}: {}", path, e);
                     return
                 }
             }
@@ -82,7 +82,7 @@ fn main() {
             match oneio::get_reader(path) {
                 Ok(reader) => {reader}
                 Err(e) => {
-                    eprintln!("cannot open {}: {}", path, e.to_string());
+                    eprintln!("cannot open {}: {}", path, e);
                     return
                 }
             }
@@ -99,7 +99,7 @@ fn main() {
         let line = match line {
             Ok(l) => {l}
             Err(e) => {
-                eprintln!("cannot read line from {}: {}", path, e.to_string());
+                eprintln!("cannot read line from {}: {}", path, e);
                 return;
             }
         };

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,8 @@ use std::fmt::{Display, Formatter};
 pub enum OneIoErrorKind {
     #[cfg(feature="remote")]
     RemoteIoError(reqwest::Error),
+    #[cfg(feature="json")]
+    JsonParsingError(serde_json::Error),
     EofError(std::io::Error),
     IoError(std::io::Error),
     NotSupported(String),
@@ -21,6 +23,8 @@ impl Display for OneIoError {
         let msg = match &self.kind {
             #[cfg(feature="remote")]
             OneIoErrorKind::RemoteIoError(e) => {e.to_string()}
+            #[cfg(feature="json")]
+            OneIoErrorKind::JsonParsingError(e) => {e.to_string()},
             OneIoErrorKind::EofError(e) => {e.to_string()}
             OneIoErrorKind::IoError(e) => {e.to_string()}
             OneIoErrorKind::NotSupported(msg) => {msg.clone()}
@@ -50,6 +54,16 @@ impl From<std::io::Error> for OneIoError {
                 std::io::ErrorKind::UnexpectedEof => { OneIoErrorKind::EofError(io_error)}
                 _ => OneIoErrorKind::IoError(io_error)
             }
+        }
+    }
+}
+
+
+#[cfg(feature="json")]
+impl From<serde_json::Error> for OneIoError {
+    fn from(error: serde_json::Error) -> Self {
+        OneIoError{
+            kind: OneIoErrorKind::JsonParsingError(error)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,7 @@ pub use error::{OneIoError, OneIoErrorKind};
 pub use crate::oneio::get_reader;
 pub use crate::oneio::get_cache_reader;
 pub use crate::oneio::get_writer;
+pub use crate::oneio::read_to_string;
 #[cfg(feature="remote")]
 pub use crate::oneio::get_remote_reader;
 #[cfg(feature="remote")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,8 @@ pub use crate::oneio::get_reader;
 pub use crate::oneio::get_cache_reader;
 pub use crate::oneio::get_writer;
 pub use crate::oneio::read_to_string;
+#[cfg(feature="json")]
+pub use crate::oneio::read_json_struct;
 #[cfg(feature="remote")]
 pub use crate::oneio::get_remote_reader;
 #[cfg(feature="remote")]

--- a/src/oneio/mod.rs
+++ b/src/oneio/mod.rs
@@ -100,6 +100,14 @@ pub fn read_to_string(path: &str) -> Result<String, OneIoError> {
     Ok(content)
 }
 
+#[cfg(feature="json")]
+/// Convenient function to directly read remote or local JSON content to a struct
+pub fn read_json_struct<T: serde::de::DeserializeOwned>(path: &str) -> Result<T, OneIoError> {
+    let reader = get_reader(path)?;
+    let res: T = serde_json::from_reader(reader)?;
+    Ok(res)
+}
+
 pub fn get_reader(path: &str) -> Result<Box<dyn BufRead>, OneIoError> {
     #[cfg(feature="remote")]
     let raw_reader: Box<dyn Read> = match path.starts_with("http") {

--- a/src/oneio/mod.rs
+++ b/src/oneio/mod.rs
@@ -53,7 +53,7 @@ pub fn get_remote_reader(path: &str, header: HashMap<String, String>) -> Result<
     let headers: HeaderMap = (&header).try_into().expect("invalid headers");
     let client = reqwest::blocking::Client::builder().default_headers(headers).build()?;
     let raw_reader: Box<dyn Read> = Box::new(client.execute(client.get(path).build()?)?);
-    let file_type = path.split(".").collect::<Vec<&str>>().last().unwrap().clone();
+    let file_type = *path.split('.').collect::<Vec<&str>>().last().unwrap();
     match file_type {
         #[cfg(feature="gz")]
         "gz" | "gzip" => {
@@ -122,7 +122,7 @@ pub fn get_reader(path: &str) -> Result<Box<dyn BufRead>, OneIoError> {
     #[cfg(not(feature="remote"))]
     let raw_reader: Box<dyn Read> = Box::new(std::fs::File::open(path)?);
 
-    let file_type = path.split(".").collect::<Vec<&str>>().last().unwrap().clone();
+    let file_type = *path.split('.').collect::<Vec<&str>>().last().unwrap();
     match file_type {
         #[cfg(feature="gz")]
         "gz" | "gzip" => {
@@ -162,7 +162,7 @@ pub fn get_cache_reader(
         match std::fs::create_dir_all(dir_path) {
             Ok(_) => {}
             Err(e) => {
-                return Err(OneIoError{ kind: OneIoErrorKind::CacheIoError(format!("cache directory creation failed: {}",e.to_string())) })
+                return Err(OneIoError{ kind: OneIoErrorKind::CacheIoError(format!("cache directory creation failed: {}",e)) })
             }
         }
     }
@@ -200,7 +200,7 @@ fn get_writer_raw(path: &str) -> Result<Box<dyn Write>, OneIoError> {
 pub fn get_writer(path: &str) -> Result<Box<dyn Write>, OneIoError> {
     let output_file = BufWriter::new(File::create(path)?);
 
-    let file_type = path.split(".").collect::<Vec<&str>>().last().unwrap().clone();
+    let file_type = *path.split('.').collect::<Vec<&str>>().last().unwrap();
     match file_type {
         #[cfg(feature = "gz")]
         "gz" | "gzip" => {

--- a/src/oneio/mod.rs
+++ b/src/oneio/mod.rs
@@ -92,6 +92,14 @@ pub fn download(remote_path: &str, local_path: &str, header: Option<HashMap<Stri
     Ok(())
 }
 
+/// Convenient function to directly read remote or local content to a String
+pub fn read_to_string(path: &str) -> Result<String, OneIoError> {
+    let mut reader = get_reader(path)?;
+    let mut content = String::new();
+    reader.read_to_string(&mut content)?;
+    Ok(content)
+}
+
 pub fn get_reader(path: &str) -> Result<Box<dyn BufRead>, OneIoError> {
     #[cfg(feature="remote")]
     let raw_reader: Box<dyn Read> = match path.starts_with("http") {

--- a/tests/oneio_test.rs
+++ b/tests/oneio_test.rs
@@ -106,3 +106,25 @@ fn test_cache_reader() {
     test_read_cache("https://spaces.bgpkit.org/oneio/test_data.txt.bz2");
     test_read_cache("https://spaces.bgpkit.org/oneio/test_data.txt.lz4");
 }
+
+#[test]
+fn test_read_json_struct() {
+    #[derive(serde::Deserialize, Debug)]
+    struct Data {
+        purpose: String,
+        version: u32,
+        meta: SubData
+    }
+    #[derive(serde::Deserialize, Debug)]
+    struct SubData {
+        float: f64,
+        success: bool
+    }
+
+    let data = oneio::read_json_struct::<Data>("https://spaces.bgpkit.org/oneio/test_data.json").unwrap();
+
+    assert_eq!(data.purpose, "test".to_string());
+    assert_eq!(data.version, 1);
+    assert_eq!(data.meta.float, 1.1);
+    assert_eq!(data.meta.success, true);
+}

--- a/tests/oneio_test.rs
+++ b/tests/oneio_test.rs
@@ -7,10 +7,11 @@ This is a test.";
 
 fn test_read( file_path: &str ) {
     let mut reader = oneio::get_reader(file_path).unwrap();
-
     let mut text = "".to_string();
     reader.read_to_string(&mut text).unwrap();
     assert_eq!(text.as_str(), TEST_TEXT);
+
+    assert_eq!(oneio::read_to_string(file_path).unwrap().as_str(), TEST_TEXT);
 
     let reader = oneio::get_reader(file_path).unwrap();
     let lines = reader.lines().into_iter().map(|line| line.unwrap()).collect::<Vec<String>>();
@@ -88,7 +89,6 @@ fn test_reader_remote_with_header() {
 
     let mut text = "".to_string();
     reader.read_to_string(&mut text).unwrap();
-    println!("{}", text);
 }
 
 #[test]


### PR DESCRIPTION
Users can now call `oneio::read_to_string(file_path).unwrap()` to get a `String` directly, or call `oneio::read_json_struct::<Data>(URL)` to read remote content to a struct.