### PR TITLE
Add read lines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ reqwest = {version="0.11", features = ["blocking"], optional=true }
 flate2 = {version = "1", optional=true }
 bzip2 = {version = "0.4", optional = true }
 lz4 = {version = "1.24", optional = true }
-clap = {version="3.2", features=["derive"], optional=true}
+clap = {version= "4.1", features=["derive"], optional=true}
 serde = {version="1.0", optional=true }
 serde_json = {version="1.0", optional=true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oneio"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 edition = "2021"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -116,8 +116,7 @@ const TEST_TEXT: &str = "OneIO test file.
 This is a test.";
 
 fn main() {
-    let reader = oneio::get_reader("https://spaces.bgpkit.org/oneio/test_data.txt.gz").unwrap();
-    let lines = reader.lines().into_iter().map(|line| line.unwrap()).collect::<Vec<String>>();
+    let lines = oneio::read_lines("https://spaces.bgpkit.org/oneio/test_data.txt.gz").map(|line| line.unwrap()).collect::<Vec<String>>();
 
     assert_eq!(lines.len(), 2);
     assert_eq!(lines[0].as_str(), "OneIO test file.");

--- a/src/bin/oneio.rs
+++ b/src/bin/oneio.rs
@@ -8,7 +8,7 @@ use std::io::Write;
 #[clap(propagate_version = true)]
 struct Cli {
     /// file to open, remote or local
-    #[clap(name = "FILE", parse(from_os_str))]
+    #[clap(name = "FILE")]
     file: PathBuf,
 
     /// download the file to current directory, similar to run `wget`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,8 +50,8 @@
 //! const TEST_TEXT: &str = "OneIO test file.
 //! This is a test.";
 //!
-//! let reader = BufReader::new(oneio::get_reader("https://spaces.bgpkit.org/oneio/test_data.txt.gz").unwrap());
-//! let lines = reader.lines().into_iter().map(|line| line.unwrap()).collect::<Vec<String>>();
+//! let lines = oneio::read_lines("https://spaces.bgpkit.org/oneio/test_data.txt.gz")
+//!     .map(|line| line.unwrap()).collect::<Vec<String>>();
 //!
 //! assert_eq!(lines.len(), 2);
 //! assert_eq!(lines[0].as_str(), "OneIO test file.");
@@ -129,6 +129,7 @@ pub use error::{OneIoError, OneIoErrorKind};
 
 pub use crate::oneio::get_reader;
 pub use crate::oneio::get_cache_reader;
+pub use crate::oneio::read_lines;
 pub use crate::oneio::get_writer;
 pub use crate::oneio::read_to_string;
 #[cfg(feature="json")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@
 //! const TEST_TEXT: &str = "OneIO test file.
 //! This is a test.";
 //!
-//! let lines = oneio::read_lines("https://spaces.bgpkit.org/oneio/test_data.txt.gz")
+//! let lines = oneio::read_lines("https://spaces.bgpkit.org/oneio/test_data.txt.gz").unwrap()
 //!     .map(|line| line.unwrap()).collect::<Vec<String>>();
 //!
 //! assert_eq!(lines.len(), 2);

--- a/src/oneio/mod.rs
+++ b/src/oneio/mod.rs
@@ -8,7 +8,7 @@ mod bzip2;
 #[cfg(feature="remote")]
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{BufWriter, Read, Write};
+use std::io::{BufRead, BufReader, BufWriter, Lines, Read, Write};
 #[cfg(feature="remote")]
 use reqwest::header::HeaderMap;
 use crate::{OneIoError, OneIoErrorKind};
@@ -106,6 +106,14 @@ pub fn read_json_struct<T: serde::de::DeserializeOwned>(path: &str) -> Result<T,
     Ok(res)
 }
 
+/// convenient function to read a file and returns a line iterator.
+pub fn read_lines(path:&str) -> Result<Lines<BufReader<Box<dyn Read>>>, OneIoError> {
+    let reader = get_reader(path)?;
+    let buf_reader = BufReader::new(reader);
+    Ok(buf_reader.lines())
+}
+
+/// get a Box<dyn Read> reader
 pub fn get_reader(path: &str) -> Result<Box<dyn Read>, OneIoError> {
     #[cfg(feature="remote")]
     let raw_reader: Box<dyn Read> = match path.starts_with("http") {

--- a/tests/oneio_test.rs
+++ b/tests/oneio_test.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::io::{BufRead, BufReader, Write};
+use std::io::Write;
 use oneio;
 
 const TEST_TEXT: &str = "OneIO test file.
@@ -13,8 +13,7 @@ fn test_read( file_path: &str ) {
 
     assert_eq!(oneio::read_to_string(file_path).unwrap().as_str(), TEST_TEXT);
 
-    let reader = BufReader::new(oneio::get_reader(file_path).unwrap());
-    let lines = reader.lines().into_iter().map(|line| line.unwrap()).collect::<Vec<String>>();
+    let lines = oneio::read_lines(file_path).unwrap().map(|line| line.unwrap()).collect::<Vec<String>>();
     assert_eq!(lines.len(), 2);
     assert_eq!(lines[0].as_str(), "OneIO test file.");
     assert_eq!(lines[1].as_str(), "This is a test.");


### PR DESCRIPTION
allowing users to directly get a line iterator without worry about
creating a `BufReader` and chain a bunch of objects together.