### PR TITLE
use thiserror to implement error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ clap = {version= "4.1", features=["derive"], optional=true}
 serde = {version="1.0", optional=true }
 serde_json = {version="1.0", optional=true }
 
+thiserror = "1.0"
+
 [features]
 default = ["all"]
 all = ["lib_only", "bin"]

--- a/src/bin/oneio.rs
+++ b/src/bin/oneio.rs
@@ -74,7 +74,7 @@ fn main() {
                     match oneio::get_cache_reader(path, dir.as_str(), cli.cache_file, cli.cache_force) {
                         Ok(reader) => {reader}
                         Err(e) => {
-                            eprintln!("cannot open {}: {}", path, e);
+                            eprintln!("Cannot open {}: {}", path, e);
                             return
                         }
                     }
@@ -83,7 +83,7 @@ fn main() {
                     match oneio::get_reader(path) {
                         Ok(reader) => {reader}
                         Err(e) => {
-                            eprintln!("cannot open {}: {}", path, e);
+                            eprintln!("Cannot open {}: {}", path, e);
                             return
                         }
                     }
@@ -102,7 +102,7 @@ fn main() {
         let line = match line {
             Ok(l) => {l}
             Err(e) => {
-                eprintln!("cannot read line from {}: {}", path, e);
+                eprintln!("Cannot read line from {}: {}", path, e);
                 return;
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@
 mod error;
 mod oneio;
 
-pub use error::{OneIoError, OneIoErrorKind};
+pub use error::OneIoError;
 
 pub use crate::oneio::get_reader;
 pub use crate::oneio::get_cache_reader;

--- a/src/oneio/lz4.rs
+++ b/src/oneio/lz4.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::io::{BufWriter, Read, Write};
 use lz4::Decoder;
 use crate::oneio::OneIOCompression;
-use crate::{OneIoError, OneIoErrorKind};
+use crate::OneIoError;
 
 pub(crate) struct OneIOLz4;
 
@@ -12,7 +12,7 @@ impl OneIOCompression for OneIOLz4 {
     }
 
     fn get_writer(_raw_writer: BufWriter<File>) -> Result<Box<dyn Write>, OneIoError> {
-        Err(OneIoError{ kind: OneIoErrorKind::NotSupported("lz4 writer is not currently supported.".to_string()) })
+        Err(OneIoError::NotSupported("lz4 writer is not currently supported.".to_string()))
     }
 }
 

--- a/src/oneio/mod.rs
+++ b/src/oneio/mod.rs
@@ -11,7 +11,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Lines, Read, Write};
 #[cfg(feature="remote")]
 use reqwest::header::HeaderMap;
-use crate::{OneIoError, OneIoErrorKind};
+use crate::OneIoError;
 
 pub trait OneIOCompression {
     fn get_reader(raw_reader: Box<dyn Read + Send>) -> Result<Box<dyn Read + Send>, OneIoError>;
@@ -167,7 +167,7 @@ pub fn get_cache_reader(
         match std::fs::create_dir_all(dir_path) {
             Ok(_) => {}
             Err(e) => {
-                return Err(OneIoError{ kind: OneIoErrorKind::CacheIoError(format!("cache directory creation failed: {}",e)) })
+                return Err(OneIoError::CacheIoError(format!("cache directory creation failed: {}",e)))
             }
         }
     }


### PR DESCRIPTION
Use [`thiserror`](https://docs.rs/crate/thiserror/latest) crate to implement custom errors.