### PR TITLE
fix confusing `cache_file_name` vs `cache_file_path` issue

### DIFF
--- a/src/oneio/mod.rs
+++ b/src/oneio/mod.rs
@@ -168,19 +168,18 @@ pub fn get_cache_reader(
         }
     }
 
-    let cache_file_path = match cache_file_name {
-        None => {
-            let file_name = path
-                .split('/')
-                .collect::<Vec<&str>>()
-                .into_iter()
-                .last()
-                .unwrap()
-                .to_string();
-            format!("{}/{}", cache_dir, file_name)
-        }
+    let cache_file_name = match cache_file_name {
+        None => path
+            .split('/')
+            .collect::<Vec<&str>>()
+            .into_iter()
+            .last()
+            .unwrap()
+            .to_string(),
         Some(p) => p,
     };
+
+    let cache_file_path = format!("{}/{}", cache_dir, cache_file_name);
 
     // if cache file already exists
     if !force_cache && std::path::Path::new(cache_file_path.as_str()).exists() {

--- a/tests/oneio_test.rs
+++ b/tests/oneio_test.rs
@@ -26,28 +26,28 @@ fn test_read(file_path: &str) {
 }
 
 fn test_read_cache(file_path: &str) {
-    let cache_file_name = format!(
-        "/tmp/{}",
-        file_path
-            .split('/')
-            .collect::<Vec<&str>>()
-            .into_iter()
-            .last()
-            .unwrap()
-            .to_string()
-    );
+    let cache_file_name = file_path
+        .split('/')
+        .collect::<Vec<&str>>()
+        .into_iter()
+        .last()
+        .unwrap()
+        .to_string();
 
-    let _ = std::fs::remove_file(cache_file_name.as_str());
+    let cache_file_path = format!("/tmp/{}", cache_file_name);
+
+    let _ = std::fs::remove_file(cache_file_path.as_str());
 
     // read from remote then cache
-    let mut reader = oneio::get_cache_reader(file_path, "/tmp", None, true).unwrap();
+    let mut reader =
+        oneio::get_cache_reader(file_path, "/tmp", Some(cache_file_name), true).unwrap();
     let mut text = "".to_string();
     reader.read_to_string(&mut text).unwrap();
     assert_eq!(text.as_str(), TEST_TEXT);
     drop(reader);
 
     // read directly from cache
-    let mut reader = oneio::get_reader(cache_file_name.as_str()).unwrap();
+    let mut reader = oneio::get_reader(cache_file_path.as_str()).unwrap();
     let mut text = "".to_string();
     reader.read_to_string(&mut text).unwrap();
     assert_eq!(text.as_str(), TEST_TEXT);


### PR DESCRIPTION
Previously, the function parameter `cache_file_name` was confusingly treated as the file path, instead of the actual file name.

https://github.com/bgpkit/oneio/blob/9987eb541a4c46775919ef1e2e0c2a482d954b28/src/oneio/mod.rs#L171

This PR fixes this issue.

Related issue: https://github.com/bgpkit/bgpkit-parser/issues/96