### PR TITLE
Add S3-related functionalities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ Cargo.lock
 
 .idea
 .DS_Store
+
+.env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["io", "util"]
 [[bin]]
 name="oneio"
 path="src/bin/oneio.rs"
-required-features=["bin"]
+required-features=["all"]
 
 [dependencies]
 # remote
@@ -29,13 +29,17 @@ lz4 = {version = "1.24", optional = true }
 clap = {version= "4.1", features=["derive"], optional=true}
 serde = {version="1.0", optional=true }
 serde_json = {version="1.0", optional=true }
+rust-s3 = {version="0.33", optional=true, default-features=false, features=["sync", "sync-native-tls"]}
+bytes = {versio="1.4.0", optional=true}
+dotenvy = {version="0.15.7", optional=true}
 
 thiserror = "1.0"
 
 [features]
 default = ["all"]
-all = ["lib_only", "bin"]
+all = ["lib_only", "bin", "s3"]
 lib_only = ["remote", "gz", "bz", "lz", "json"]
+s3= ["rust-s3", "bytes", "dotenvy"]
 
 remote=["reqwest"]
 gz = ["flate2"]

--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ oneio = {version = "0.9.0", features = ["remote", "gz"]}
 ```
 
 Supported feature flags:
-- `all` (**default**): all flags (`["gz", "bz", "lz", "remote", "json"]`)
+- `all` (**default**): all flags (`["gz", "bz", "lz", "remote", "json", "s3"]`)
 - `remote`: allow reading from remote files
 - `gz`: support `gzip` files
 - `bz`: support `bzip2` files
 - `lz`: support `lz4` files
 - `json`: allow reading JSON content into structs directly
+- `s3`: allow reading from AWS S3 compatible buckets
 
 ## Use `oneio` commandline tool
 
@@ -133,6 +134,7 @@ fn main() {
 
 ### Example
 
+#### Common IO operations
 ```rust
 fn main() {
     let to_read_file = "https://spaces.bgpkit.org/oneio/test_data.txt.gz";
@@ -157,7 +159,8 @@ fn main() {
 }
 ```
 
-Read remote content with custom headers
+#### Read remote content with custom headers
+
 ```rust
 use std::collections::HashMap;
 fn main() {
@@ -171,7 +174,8 @@ fn main() {
 }
 ```
 
-Download remote file to local directory
+#### Download remote file to local directory
+
 ```rust
 fn main() {
     oneio::download(
@@ -179,5 +183,35 @@ fn main() {
         "updates.gz",
         None
     ).unwrap();
+}
+```
+
+#### S3-related operations (needs `s3` feature flag)
+```rust
+fn main() {
+    // upload to S3
+    s3_upload("oneio-test", "test/README.md", "README.md").unwrap();
+
+    // read directly from S3
+    let mut content = String::new();
+    s3_reader("oneio-test", "test/README.md")
+        .unwrap()
+        .read_to_string(&mut content)
+        .unwrap();
+    println!("{}", content);
+
+    // download from S3
+    s3_download("oneio-test", "test/README.md", "test/README-2.md").unwrap();
+
+    // get S3 file stats
+    let res = s3_stats("oneio-test", "test/README.md").unwrap();
+    dbg!(res);
+
+    // error if file does not exist
+    let res = s3_stats("oneio-test", "test/README___NON_EXISTS.md");
+    assert!(res.is_err());
+    
+    // list S3 files
+    let res = s3_list("oneio-test", "test/", Some("/")).unwrap();
 }
 ```

--- a/examples/s3_operations.rs
+++ b/examples/s3_operations.rs
@@ -1,4 +1,4 @@
-use oneio::{s3_download, s3_reader, s3_upload};
+use oneio::{s3_download, s3_list, s3_reader, s3_stats, s3_upload};
 use std::io::Read;
 
 /// This example shows how to upload a file to S3 and read it back.
@@ -9,8 +9,10 @@ use std::io::Read;
 /// - AWS_REGION (e.g. "us-east-1") (use "auto" for Cloudflare R2)
 /// - AWS_ENDPOINT
 fn main() {
+    // upload to S3
     s3_upload("oneio-test", "test/README.md", "README.md").unwrap();
 
+    // read directly from S3
     let mut content = String::new();
     s3_reader("oneio-test", "test/README.md")
         .unwrap()
@@ -18,5 +20,14 @@ fn main() {
         .unwrap();
     println!("{}", content);
 
+    // download from S3
     s3_download("oneio-test", "test/README.md", "test/README-2.md").unwrap();
+
+    // get S3 file stats
+    let res = s3_stats("oneio-test", "test/README.md").unwrap();
+    dbg!(res);
+
+    // error if file does not exist
+    let res = s3_stats("oneio-test", "test/README___NON_EXISTS.md");
+    assert!(res.is_err());
 }

--- a/examples/s3_operations.rs
+++ b/examples/s3_operations.rs
@@ -30,4 +30,8 @@ fn main() {
     // error if file does not exist
     let res = s3_stats("oneio-test", "test/README___NON_EXISTS.md");
     assert!(res.is_err());
+
+    // list S3 files
+    let res = s3_list("oneio-test", "test/", Some("/")).unwrap();
+    dbg!(res);
 }

--- a/examples/s3_operations.rs
+++ b/examples/s3_operations.rs
@@ -1,0 +1,22 @@
+use oneio::{s3_download, s3_reader, s3_upload};
+use std::io::Read;
+
+/// This example shows how to upload a file to S3 and read it back.
+///
+/// You need to set the following environment variables (e.g. in .env):
+/// - AWS_ACCESS_KEY_ID
+/// - AWS_SECRET_ACCESS_KEY
+/// - AWS_REGION (e.g. "us-east-1") (use "auto" for Cloudflare R2)
+/// - AWS_ENDPOINT
+fn main() {
+    s3_upload("oneio-test", "test/README.md", "README.md").unwrap();
+
+    let mut content = String::new();
+    s3_reader("oneio-test", "test/README.md")
+        .unwrap()
+        .read_to_string(&mut content)
+        .unwrap();
+    println!("{}", content);
+
+    s3_download("oneio-test", "test/README.md", "test/README-2.md").unwrap();
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,19 @@ pub enum OneIoError {
     NotSupported(String),
     #[error("Cache IO error: {0}")]
     CacheIoError(String),
+
+    #[cfg(feature = "s3")]
+    #[error("S3 IO error: {0}")]
+    S3IoError(#[from] s3::error::S3Error),
+    #[cfg(feature = "s3")]
+    #[error("S3 credential error: {0}")]
+    S3CredentialError(#[from] s3::creds::error::CredentialsError),
+    #[cfg(feature = "s3")]
+    #[error("S3 region error: {0}")]
+    S3RegionError(#[from] s3::region::error::RegionError),
+    #[cfg(feature = "s3")]
+    #[error("S3 download error: code {0}")]
+    S3DownloadError(u16),
 }
 
 impl From<std::io::Error> for OneIoError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,3 +138,11 @@ pub use crate::oneio::get_writer;
 pub use crate::oneio::read_json_struct;
 pub use crate::oneio::read_lines;
 pub use crate::oneio::read_to_string;
+#[cfg(feature = "s3")]
+pub use crate::oneio::s3::s3_bucket;
+#[cfg(feature = "s3")]
+pub use crate::oneio::s3::s3_download;
+#[cfg(feature = "s3")]
+pub use crate::oneio::s3::s3_reader;
+#[cfg(feature = "s3")]
+pub use crate::oneio::s3::s3_upload;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,10 @@ pub use crate::oneio::s3::s3_bucket;
 #[cfg(feature = "s3")]
 pub use crate::oneio::s3::s3_download;
 #[cfg(feature = "s3")]
+pub use crate::oneio::s3::s3_list;
+#[cfg(feature = "s3")]
 pub use crate::oneio::s3::s3_reader;
+#[cfg(feature = "s3")]
+pub use crate::oneio::s3::s3_stats;
 #[cfg(feature = "s3")]
 pub use crate::oneio::s3::s3_upload;


### PR DESCRIPTION
Add the following S3-related functionalities:
- get bucket
- download s3 file
- upload file to s3
- get a reader for s3 file
- get file stats
- list files (with our without delimiter)

Example:
```rust
use oneio::{s3_download, s3_list, s3_reader, s3_stats, s3_upload};
use std::io::Read;

/// This example shows how to upload a file to S3 and read it back.
///
/// You need to set the following environment variables (e.g. in .env):
/// - AWS_ACCESS_KEY_ID
/// - AWS_SECRET_ACCESS_KEY
/// - AWS_REGION (e.g. "us-east-1") (use "auto" for Cloudflare R2)
/// - AWS_ENDPOINT
fn main() {
    // upload to S3
    s3_upload("oneio-test", "test/README.md", "README.md").unwrap();

    // read directly from S3
    let mut content = String::new();
    s3_reader("oneio-test", "test/README.md")
        .unwrap()
        .read_to_string(&mut content)
        .unwrap();
    println!("{}", content);

    // download from S3
    s3_download("oneio-test", "test/README.md", "test/README-2.md").unwrap();

    // get S3 file stats
    let res = s3_stats("oneio-test", "test/README.md").unwrap();
    dbg!(res);

    // error if file does not exist
    let res = s3_stats("oneio-test", "test/README___NON_EXISTS.md");
    assert!(res.is_err());

    // list S3 files
    let res = s3_list("oneio-test", "test/", Some("/")).unwrap();
    dbg!(res);
}
```

This address issue #12 