### PR TITLE
add anonymous ftp support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oneio"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 edition = "2021"
 readme = "README.md"
@@ -11,7 +11,7 @@ description = """
 OneIO is a Rust library that provides unified simple IO interface for
 reading and writing to and from data files from different sources and compressions.
 """
-keywords = ["io", "util", "s3"]
+keywords = ["io", "util", "s3", "ftp"]
 
 [[bin]]
 name="oneio"
@@ -29,6 +29,7 @@ lz4 = {version = "1.24", optional = true }
 
 # cli
 clap = {version= "4.1", features=["derive"], optional=true}
+tracing = {version="0.1.37", optional=true}
 
 # json
 serde = {version="1.0", optional=true }
@@ -38,6 +39,9 @@ serde_json = {version="1.0", optional=true }
 rust-s3 = {version="0.33", optional=true, default-features=false, features=["sync", "sync-native-tls"]}
 dotenvy = {version="0.15.7", optional=true}
 
+# ftp
+suppaftp = { version = "^5.1.0", features = ["native-tls"], optional = true }
+
 thiserror = "1.0"
 
 [features]
@@ -46,11 +50,11 @@ all = ["lib", "cli", "s3"]
 lib = ["remote", "gz", "bz", "lz", "json"]
 s3= ["rust-s3", "dotenvy"]
 
-remote=["reqwest"]
+remote=["reqwest", "suppaftp"]
 gz = ["flate2"]
 bz = ["bzip2"]
 lz = ["lz4"]
-cli = ["clap"]
+cli = ["clap", "tracing"]
 json = ["serde", "serde_json"]
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -11,18 +11,18 @@ OneIO is a Rust library that provides unified simple IO interface for reading an
 
 Enable all compression algorithms, and handle remote files (default)
 ```toml
-oneio = "0.11"
+oneio = "0.12"
 ```
 
 Select from supported feature flags
 ```toml
-oneio = {version = "0.11", default-features=false, features = ["remote", "gz"]}
+oneio = {version = "0.12", default-features=false, features = ["remote", "gz"]}
 ```
 
 Supported feature flags:
 - `lib` (*default*): `["gz", "bz", "lz", "remote", "json"]`
 - `all`: all flags (`["gz", "bz", "lz", "remote", "json", "s3"]`
-- `remote`: allow reading from remote files
+- `remote`: allow reading from remote files, including http(s) and ftp
 - `gz`: support `gzip` files
 - `bz`: support `bzip2` files
 - `lz`: support `lz4` files

--- a/src/bin/oneio.rs
+++ b/src/bin/oneio.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use std::io::Write;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
+use tracing::error;
 
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
@@ -93,8 +94,8 @@ fn main() {
         let line = match line {
             Ok(l) => l,
             Err(e) => {
-                eprintln!("Cannot read line from {}: {}", path, e);
-                return;
+                error!("Cannot read line from {}: {}", path, e);
+                continue;
             }
         };
         if !cli.stats {

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,9 @@ pub enum OneIoError {
     #[cfg(feature = "remote")]
     #[error("remote IO error: {0}")]
     RemoteIoError(#[from] reqwest::Error),
+    #[cfg(feature = "remote")]
+    #[error("FTP error: {0}")]
+    FptError(#[from] suppaftp::FtpError),
     #[cfg(feature = "json")]
     #[error("JSON object parsing error: {0}")]
     JsonParsingError(#[from] serde_json::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,11 @@
 //! std::fs::remove_file(to_write_file).unwrap();
 //! ```
 
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/bgpkit/assets/main/logos/icon-transparent.png",
+    html_favicon_url = "https://raw.githubusercontent.com/bgpkit/assets/main/logos/favicon.ico"
+)]
+
 mod error;
 mod oneio;
 


### PR DESCRIPTION
Anonymous FTP support is added to the `remote` feature and comes as default for `oneio`.

CLI usage example:
```
oneio  ftp://ftp.radb.net/radb/dbase/radb.db.gz 
```

This resolves #19 