### PR TITLE
easier selection of `rustls` or `native-tls`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,10 +24,10 @@ jobs:
         run: cargo build --no-default-features
 
       - name: Build lib with native-tls
-        run: cargo build --features lib,native-tls
+        run: cargo build --features lib-native-tls
 
       - name: Build lib with rustls
-        run: cargo build --features lib,rustls
+        run: cargo build --features lib-rustls
 
       - name: Build lib with all features
         run: cargo build --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,11 @@ thiserror = "1.0"
 [features]
 default = ["lib"]
 all = ["lib", "cli", "s3"]
-lib = ["remote", "native-tls", "gz", "bz", "lz", "json"]
-s3= ["rust-s3", "native-tls", "dotenvy"]
+lib = ["lib-native-tls"]
+lib-native-tls = ["remote", "native-tls", "gz", "bz", "lz", "json"]
+lib-rustls = ["remote", "rustls", "gz", "bz", "lz", "json"]
+
+# optional flags to select native-tls or rust-tls
 native-tls = ["reqwest?/default-tls", "suppaftp?/native-tls", "rust-s3?/sync-native-tls"]
 rustls = ["reqwest?/rustls-tls", "suppaftp?/rustls", "rust-s3?/sync-rustls-tls"]
 
@@ -58,6 +61,7 @@ bz = ["bzip2"]
 lz = ["lz4"]
 cli = ["clap", "tracing"]
 json = ["serde", "serde_json"]
+s3= ["rust-s3", "native-tls", "dotenvy"]
 
 [dev-dependencies]
 serde = {version="1.0", features=["derive"]}

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ oneio = {version = "0.13", default-features=false, features = ["remote", "gz"]}
 Supported feature flags:
 - `lib` (*default*): `["gz", "bz", "lz", "remote", "json"]`
 - `all`: all flags (`["gz", "bz", "lz", "remote", "json", "s3"]`
+- `lib-rustls`: use `rustls` instead of `native-tls` for remote files via https or S3, if either are enabled
 - `remote`: allow reading from remote files, including http(s) and ftp
-- `rustls`: use `rustls` instead of `native-tls` for remote files via https or S3, if either are enabled
 - `gz`: support `gzip` files
 - `bz`: support `bzip2` files
 - `lz`: support `lz4` files


### PR DESCRIPTION
downstream library crates can use the following flags for simpler rustls or native-tls choice:

- `lib`: alias for `lib-native-tls`
- `lib-native-tls`: `["remote", "native-tls", "gz", "bz", "lz", "json"]`
- `lib-rustls`: `["remote", "rustls", "gz", "bz", "lz", "json"]`