### PR TITLE
Fix FTP reader and downloader

### DIFF
--- a/src/bin/oneio.rs
+++ b/src/bin/oneio.rs
@@ -45,7 +45,7 @@ fn main() {
         let out_path = match outfile {
             None => {
                 // infer file path and download to current directory
-                if !path.starts_with("http") {
+                if !path.starts_with("http") && !path.starts_with("ftp") {
                     eprintln!("{} is not a remote file, skip downloading", path);
                     return;
                 }

--- a/src/oneio/mod.rs
+++ b/src/oneio/mod.rs
@@ -110,10 +110,18 @@ pub fn download(
     local_path: &str,
     header: Option<HashMap<String, String>>,
 ) -> Result<(), OneIoError> {
-    let mut response = get_remote_http_raw(remote_path, header.unwrap_or_default())?;
     let mut writer = get_writer_raw(local_path)?;
 
-    response.copy_to(&mut writer)?;
+    if remote_path.starts_with("http") {
+        let mut response = get_remote_http_raw(remote_path, header.unwrap_or_default())?;
+        response.copy_to(&mut writer)?;
+    } else if remote_path.starts_with("ftp") {
+        let mut reader = get_remote_ftp_raw(remote_path)?;
+        std::io::copy(&mut reader, &mut writer)?;
+    } else {
+        return Err(OneIoError::NotSupported(remote_path.to_string()));
+    };
+
     Ok(())
 }
 

--- a/src/oneio/mod.rs
+++ b/src/oneio/mod.rs
@@ -65,6 +65,7 @@ fn get_remote_ftp_raw(path: &str) -> Result<Box<dyn Read + Send>, OneIoError> {
 
     let mut ftp_stream = suppaftp::FtpStream::connect(socket)?;
     ftp_stream.login("anonymous", "oneio").unwrap();
+    ftp_stream.transfer_type(suppaftp::types::FileType::Binary)?;
     let reader = Box::new(ftp_stream.retr_as_stream(path.as_str())?);
     Ok(reader)
 }


### PR DESCRIPTION
Previously, without setting FTP transfer type, the download stream produces unexpected bytes and not usable for remote binary files over FTP (e.g. gz files).

This PR fixes this issue by setting the FTP transfer type to `BINARY`.
```
➜  oneio ftp://ftp.radb.net/radb/dbase/radb.db.gz | head    
route:          1.0.0.0/24
descr:          QRATOR via EMIX
origin:         AS13335
mnt-by:         MAINT-AS8966
changed:        noc@emix.net.ae 20230803
source:         RADB
last-modified:  2023-11-13T16:17:56Z

route:          1.0.4.0/22
descr:          Proxy route object registered by AS2764
```

This PR also enables downloading files over FTP using the CLI.

```
➜  oneio ftp://ftp.radb.net/radb/dbase/radb.db.gz --download
file successfully downloaded to radb.db.gz
➜  oneio radb.db.gz| head -n 20                             
route:          1.0.0.0/24
descr:          QRATOR via EMIX
origin:         AS13335
mnt-by:         MAINT-AS8966
changed:        noc@emix.net.ae 20230803
source:         RADB
last-modified:  2023-11-13T16:17:56Z

route:          1.0.4.0/22
descr:          Proxy route object registered by AS2764

```