### PR TITLE
Multi-part object-storage file upload

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ description = """
 OneIO is a Rust library that provides unified simple IO interface for
 reading and writing to and from data files from different sources and compressions.
 """
+default-run = "oneio"
 keywords = ["io", "util", "s3", "ftp"]
 
 [[bin]]

--- a/src/bin/oneio.rs
+++ b/src/bin/oneio.rs
@@ -42,12 +42,12 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Parse individual MRT files given a file path, local or remote.
+    /// Upload file to S3-compatible object storage
     UploadToS3 {
-        /// File path to a MRT file, local or remote.
+        /// S3 bucket name
         s3_bucket: String,
 
-        /// Output as JSON objects
+        /// S3 file path (starting with `/`)
         s3_path: String,
     },
 }

--- a/src/bin/oneio.rs
+++ b/src/bin/oneio.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use std::io::Write;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
@@ -35,12 +35,47 @@ struct Cli {
     /// read through file and only print out stats
     #[clap(short, long)]
     stats: bool,
+
+    #[clap(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Parse individual MRT files given a file path, local or remote.
+    UploadToS3 {
+        /// File path to a MRT file, local or remote.
+        s3_bucket: String,
+
+        /// Output as JSON objects
+        s3_path: String,
+    },
 }
 
 fn main() {
     let cli = Cli::parse();
     let path: &str = cli.file.to_str().unwrap();
     let outfile: Option<PathBuf> = cli.outfile;
+
+    if let Some(command) = cli.command {
+        match command {
+            Commands::UploadToS3 { s3_bucket, s3_path } => {
+                match oneio::s3_upload(s3_bucket.as_str(), s3_path.as_str(), path) {
+                    Ok(_) => {
+                        println!(
+                            "file successfully uploaded to s3://{}/{}",
+                            s3_bucket, s3_path
+                        );
+                    }
+                    Err(e) => {
+                        eprintln!("file upload error: {}", e);
+                    }
+                }
+            }
+        }
+        return;
+    }
+
     if cli.download {
         let out_path = match outfile {
             None => {

--- a/src/oneio/s3.rs
+++ b/src/oneio/s3.rs
@@ -38,9 +38,7 @@ pub fn s3_reader(bucket: &str, path: &str) -> Result<Box<dyn Read + Send>, OneIo
 pub fn s3_upload(bucket: &str, s3_path: &str, file_path: &str) -> Result<(), OneIoError> {
     let bucket = s3_bucket(bucket)?;
     let mut reader = get_reader_raw(file_path)?;
-    let mut bytes: Vec<u8> = vec![];
-    reader.read_to_end(&mut bytes)?;
-    bucket.put_object(s3_path, bytes.as_slice())?;
+    bucket.put_object_stream(&mut reader, s3_path)?;
     Ok(())
 }
 


### PR DESCRIPTION
This PR replaces the use of `bucket.put_object` to `bucket.put_object_stream`, which uses the multi-part upload API. This enables users to upload very large files with the `s3_upload` function without changing interfaces.

This PR also adds a new `upload-to-s3` subcommand to enable uploading files to s3 directly.

This PR resolves issue #18.