### PR TITLE
Add support for tgz (tar.gz) files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ required-features=["cli"]
 reqwest = {version="0.11", default-features=false, features = ["blocking"], optional=true }
 
 # compression
-flate2 = {version = "1", optional=true }
+libflate = {version = "2", optional=true }
 bzip2 = {version = "0.4.4", optional = true }
 lz4 = {version = "1.24", optional = true }
 xz2 = {version = "0.1", optional = true }
@@ -60,7 +60,7 @@ rustls = ["reqwest?/rustls-tls", "suppaftp?/rustls", "rust-s3?/sync-rustls-tls"]
 
 # supported compression algorithms, can be tuggled on/off individually
 compressions = ["gz", "bz", "lz", "xz"]
-gz = ["flate2"]
+gz = ["libflate"]
 bz = ["bzip2"]
 lz = ["lz4"]
 xz = ["xz2"]
@@ -74,6 +74,7 @@ s3= ["rust-s3", "native-tls", "dotenvy"]
 
 [dev-dependencies]
 serde = {version="1.0", features=["derive"]}
+tar = "0.4"
 
 # This list only includes examples which require additional features to run. These are more in the examples' directory.
 [[example]]

--- a/examples/read_csv_in_tar.rs
+++ b/examples/read_csv_in_tar.rs
@@ -1,0 +1,24 @@
+use std::io::Read;
+use std::thread::sleep;
+use std::time::Duration;
+
+fn main() {
+    let reader = oneio::get_reader("http://josephine.sobornost.net/josephine.sobornost.net/rpkidata/2023/08/04/rpki-20230804T000430Z.tgz").unwrap();
+    let mut ar = tar::Archive::new(reader);
+    println!("processing rpkiviews tar file at http://josephine.sobornost.net/josephine.sobornost.net/rpkidata/2023/08/04/rpki-20230804T000430Z.tgz");
+    println!("searching for any files in tar that ends with .csv");
+    for entry in ar.entries().unwrap() {
+        let mut entry = entry.unwrap();
+        let path = entry.path().unwrap().to_string_lossy().to_string();
+        if path.ends_with("csv") {
+            println!("found file {}", &path);
+            println!("reading content now... (sleep for 3 seconds)");
+            sleep(Duration::from_secs(3));
+            let mut content: String = String::default();
+            entry.read_to_string(&mut content).unwrap();
+            for line in content.lines() {
+                println!("{}", line);
+            }
+        }
+    }
+}

--- a/src/oneio/compressions/gzip.rs
+++ b/src/oneio/compressions/gzip.rs
@@ -1,5 +1,6 @@
 use crate::oneio::OneIOCompression;
 use crate::OneIoError;
+use libflate::finish::AutoFinishUnchecked;
 use libflate::gzip::Decoder;
 use libflate::gzip::Encoder;
 use std::fs::File;
@@ -13,6 +14,8 @@ impl OneIOCompression for OneIOGzip {
     }
 
     fn get_writer(raw_writer: BufWriter<File>) -> Result<Box<dyn Write>, OneIoError> {
-        Ok(Box::new(Encoder::new(raw_writer)?))
+        // see libflate docs on the reasons of using [AutoFinishUnchecked].
+        let encoder = AutoFinishUnchecked::new(Encoder::new(raw_writer)?);
+        Ok(Box::new(encoder))
     }
 }

--- a/src/oneio/compressions/gzip.rs
+++ b/src/oneio/compressions/gzip.rs
@@ -1,8 +1,7 @@
 use crate::oneio::OneIOCompression;
 use crate::OneIoError;
-use flate2::read::GzDecoder;
-use flate2::write::GzEncoder;
-use flate2::Compression;
+use libflate::gzip::Decoder;
+use libflate::gzip::Encoder;
 use std::fs::File;
 use std::io::{BufWriter, Read, Write};
 
@@ -10,10 +9,10 @@ pub(crate) struct OneIOGzip;
 
 impl OneIOCompression for OneIOGzip {
     fn get_reader(raw_reader: Box<dyn Read + Send>) -> Result<Box<dyn Read + Send>, OneIoError> {
-        Ok(Box::new(GzDecoder::new(raw_reader)))
+        Ok(Box::new(Decoder::new(raw_reader)?))
     }
 
     fn get_writer(raw_writer: BufWriter<File>) -> Result<Box<dyn Write>, OneIoError> {
-        Ok(Box::new(GzEncoder::new(raw_writer, Compression::default())))
+        Ok(Box::new(Encoder::new(raw_writer)?))
     }
 }

--- a/src/oneio/mod.rs
+++ b/src/oneio/mod.rs
@@ -175,7 +175,7 @@ pub fn get_reader(path: &str) -> Result<Box<dyn Read + Send>, OneIoError> {
     let file_type = *path.split('.').collect::<Vec<&str>>().last().unwrap();
     match file_type {
         #[cfg(feature = "gz")]
-        "gz" | "gzip" => compressions::gzip::OneIOGzip::get_reader(raw_reader),
+        "gz" | "gzip" | "tgz" => compressions::gzip::OneIOGzip::get_reader(raw_reader),
         #[cfg(feature = "bz")]
         "bz2" | "bz" => compressions::bzip2::OneIOBzip2::get_reader(raw_reader),
         #[cfg(feature = "lz4")]
@@ -260,7 +260,7 @@ pub fn get_writer(path: &str) -> Result<Box<dyn Write>, OneIoError> {
     let file_type = *path.split('.').collect::<Vec<&str>>().last().unwrap();
     match file_type {
         #[cfg(feature = "gz")]
-        "gz" | "gzip" => compressions::gzip::OneIOGzip::get_writer(output_file),
+        "gz" | "gzip" | "tgz" => compressions::gzip::OneIOGzip::get_writer(output_file),
         #[cfg(feature = "bz")]
         "bz2" | "bz" => compressions::bzip2::OneIOBzip2::get_writer(output_file),
         #[cfg(feature = "lz4")]


### PR DESCRIPTION
This PR adds the support for `.tgz` suffix and replaces the `flate2` library with `libflate` for handling large tar.gzip files. `flate2` errors out when reading large files like http://josephine.sobornost.net/josephine.sobornost.net/rpkidata/2023/08/04/rpki-20230804T000430Z.tgz.