### PR TITLE
add function to check s3 env variables set

### DIFF
--- a/src/oneio/s3.rs
+++ b/src/oneio/s3.rs
@@ -12,6 +12,14 @@ use s3::serde_types::{HeadObjectResult, ListBucketResult};
 use s3::{Bucket, Region};
 use std::io::{Cursor, Read};
 
+/// Check if the environment variables for S3 are set.
+pub fn s3_env_check() -> Result<(), OneIoError> {
+    dotenvy::dotenv().ok();
+    let _ = Region::from_default_env()?;
+    let _ = Credentials::from_env()?;
+    Ok(())
+}
+
 /// Get a S3 bucket object from the given bucket name.
 pub fn s3_bucket(bucket: &str) -> Result<Bucket, OneIoError> {
     dotenvy::dotenv().ok();


### PR DESCRIPTION
Use `oneio::s3_env_check()` function to check if all required environment variables are set.

Example:
```rust
                if let Err(e) = oneio::s3_env_check() {
                    eprintln!("missing s3 credentials");
                    eprintln!("{}", e.to_string());
                    exit(1);
                }
```