### PR TITLE
add s3_url_parse utility function

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,9 @@ pub enum OneIoError {
     #[error("S3 credential error: {0}")]
     S3CredentialError(#[from] s3::creds::error::CredentialsError),
     #[cfg(feature = "s3")]
+    #[error("S3 invalid url: {0}")]
+    S3UrlError(String),
+    #[cfg(feature = "s3")]
     #[error("S3 region error: {0}")]
     S3RegionError(#[from] s3::region::error::RegionError),
     #[cfg(feature = "s3")]


### PR DESCRIPTION
Usage:
```rust
    #[test]
    fn test_s3_url_parse() {
        const S3_URL: &str = "s3://test-bucket/test-path/test-file.txt";
        let (bucket, path) = s3_url_parse(S3_URL).unwrap();
        assert_eq!(bucket, "test-bucket");
        assert_eq!(path, "test-path/test-file.txt");

        const NON_S3_URL: &str = "http://test-bucket/test-path/test-file.txt";
        assert!(s3_url_parse(NON_S3_URL).is_err());
    }
```