### PR TITLE
Add `s3_copy` and `s3_delete` functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,22 @@ fn main() {
     // error if file does not exist
     let res = s3_stats("oneio-test", "test/README___NON_EXISTS.md");
     assert!(res.is_err());
+
+    // copy S3 file to a different location
+    let res = s3_copy("oneio-test", "test/README.md", "test/README-temporary.md");
+    assert!(res.is_ok());
+    assert_eq!(
+        true,
+        s3_exists("oneio-test", "test/README-temporary.md").unwrap()
+    );
+
+    // delete temporary copied S3 file
+    let res = s3_delete("oneio-test", "test/README-temporary.md");
+    assert!(res.is_ok());
+    assert_eq!(
+        false,
+        s3_exists("oneio-test", "test/README-temporary.md").unwrap()
+    );
     
     // list S3 files
     let res = s3_list("oneio-test", "test/", Some("/")).unwrap();

--- a/examples/s3_operations.rs
+++ b/examples/s3_operations.rs
@@ -1,4 +1,4 @@
-use oneio::{s3_download, s3_exists, s3_list, s3_reader, s3_stats, s3_upload};
+use oneio::{s3_copy, s3_delete, s3_download, s3_exists, s3_list, s3_reader, s3_stats, s3_upload};
 use std::io::Read;
 
 /// This example shows how to upload a file to S3 and read it back.
@@ -30,12 +30,27 @@ fn main() {
     // error if file does not exist
     let res = s3_stats("oneio-test", "test/README___NON_EXISTS.md");
     assert!(res.is_err());
-
     assert_eq!(
         false,
         s3_exists("oneio-test", "test/README___NON_EXISTS.md").unwrap()
     );
     assert_eq!(true, s3_exists("oneio-test", "test/README.md").unwrap());
+
+    // copy S3 file to a different location
+    let res = s3_copy("oneio-test", "test/README.md", "test/README-temporary.md");
+    assert!(res.is_ok());
+    assert_eq!(
+        true,
+        s3_exists("oneio-test", "test/README-temporary.md").unwrap()
+    );
+
+    // delete temporary copied S3 file
+    let res = s3_delete("oneio-test", "test/README-temporary.md");
+    assert!(res.is_ok());
+    assert_eq!(
+        false,
+        s3_exists("oneio-test", "test/README-temporary.md").unwrap()
+    );
 
     // list S3 files
     let res = s3_list("oneio-test", "test/", Some("/")).unwrap();


### PR DESCRIPTION
## Description:
This PR introduces two new functions: `s3_copy` and `s3_delete` to our Rust codebase. The `s3_copy` function allows copying objects within an S3 bucket, while the `s3_delete` function allows deleting objects from an S3 bucket.

## Changes include

- `s3_copy` and `s3_delete` functions have been added.
- Functions in the `s3.rs` file are now accompanied by comprehensive comments explaining their operation and example usage.
- The existing functions have been refined to now include checks for necessary S3 operation environment variables, parsing S3 URLs into buckets and key strings, creation of S3 bucket objects, reading and uploading files to S3, as well as checks for the existence of an S3 object and listings of S3 objects.

This PR enhances the functionality of our existing S3 operations in Rust, providing users with more capabilities to interact with their S3 resources.