### PR TITLE
disable http caching for cli requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,11 +66,14 @@ lz = ["lz4"]
 xz = ["xz2"]
 
 remote=["reqwest", "suppaftp"]
-cli = ["clap", "tracing", "s3"]
+cli = ["clap", "tracing", "s3", "no-cache"]
 json = ["serde", "serde_json"]
 
 # s3 support, off by default
 s3= ["rust-s3", "native-tls", "dotenvy"]
+
+# no-cache
+no-cache = []
 
 [dev-dependencies]
 serde = {version="1.0", features=["derive"]}

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Supported feature flags:
 - `xz`: support `xz` files
 - `json`: allow reading JSON content into structs directly
 - `s3`: allow reading from AWS S3 compatible buckets
+- `no-cache`: disable caching for reading remote files
 
 ## Use `oneio` commandline tool
 

--- a/src/oneio/mod.rs
+++ b/src/oneio/mod.rs
@@ -57,7 +57,16 @@ fn get_remote_http_raw(
     path: &str,
     header: HashMap<String, String>,
 ) -> Result<reqwest::blocking::Response, OneIoError> {
-    let headers: reqwest::header::HeaderMap = (&header).try_into().expect("invalid headers");
+    let mut headers: reqwest::header::HeaderMap = (&header).try_into().expect("invalid headers");
+    headers.insert(
+        reqwest::header::USER_AGENT,
+        reqwest::header::HeaderValue::from_static("oneio"),
+    );
+    #[cfg(feature = "no-cache")]
+    headers.insert(
+        reqwest::header::CACHE_CONTROL,
+        reqwest::header::HeaderValue::from_static("no-cache"),
+    );
     let client = reqwest::blocking::Client::builder()
         .default_headers(headers)
         .build()?;


### PR DESCRIPTION
this feature is controlled by `no-cache` feature flag and is turned on by default for cli, but not for lib