### PR TITLE
cli depends on rustls by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ lz = ["lz4"]
 xz = ["xz2"]
 
 remote=["reqwest", "suppaftp"]
-cli = ["clap", "tracing", "s3", "no-cache"]
+cli = ["clap", "tracing", "s3", "no-cache", "rustls"]
 json = ["serde", "serde_json"]
 
 # s3 support, off by default


### PR DESCRIPTION
This allows us to build images without the hassle of handling openssl local dependencies.