### PR TITLE
add subcommand for s3 list

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Build lib with all features
         run: cargo build --all-features
 
-      - name: Run test for lib feature
-        run: cargo test --features lib --test oneio_test
+      - name: Run test for lib + s3 features (s3 for doc compilation tests)
+        run: cargo test --features s3
 
       - name: Run format check
         run: cargo fmt --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ lz4 = {version = "1.24", optional = true }
 xz2 = {version = "0.1", optional = true }
 
 # cli
-clap = {version= "4.1", features=["derive"], optional=true}
+clap = {version= "4.4", features=["derive"], optional=true}
 tracing = {version="0.1.37", optional=true}
 
 # json

--- a/examples/s3_operations.rs
+++ b/examples/s3_operations.rs
@@ -55,7 +55,7 @@ fn main() {
     );
 
     info!("list S3 files");
-    let res = s3_list("oneio-test", "test/", Some("/")).unwrap();
+    let res = s3_list("oneio-test", "test/", Some("/".to_string()), false).unwrap();
     dbg!(res);
 
     info!("read compressed s3 file by url");

--- a/src/bin/oneio.rs
+++ b/src/bin/oneio.rs
@@ -57,17 +57,27 @@ enum S3Commands {
         #[clap()]
         bucket: String,
 
-        /// S3 file path (starting with `/`)
+        /// S3 file path
         #[clap()]
         path: String,
     },
     /// List S3 bucket
     List {
+        /// S3 bucket name
         #[clap()]
         bucket: String,
 
-        #[clap()]
+        /// S3 file path
+        #[clap(default_value = "")]
         prefix: String,
+
+        /// delimiter for directory listing
+        #[clap(short, long, default_value = "/")]
+        delimiter: String,
+
+        /// showing directories only
+        #[clap(short, long)]
+        dirs: bool,
     },
 }
 
@@ -102,13 +112,18 @@ fn main() {
                     }
                     return;
                 }
-                S3Commands::List { bucket, prefix } => {
+                S3Commands::List {
+                    bucket,
+                    prefix,
+                    delimiter,
+                    dirs,
+                } => {
                     if let Err(e) = oneio::s3_env_check() {
                         eprintln!("missing s3 credentials");
                         eprintln!("{}", e);
                         exit(1);
                     }
-                    match oneio::s3_list(bucket.as_str(), prefix.as_str(), None) {
+                    match oneio::s3_list(bucket.as_str(), prefix.as_str(), Some(delimiter), dirs) {
                         Ok(paths) => {
                             paths.iter().for_each(|p| println!("{p}"));
                         }

--- a/src/oneio/s3.rs
+++ b/src/oneio/s3.rs
@@ -156,17 +156,17 @@ pub fn s3_bucket(bucket: &str) -> Result<Bucket, OneIoError> {
 ///
 /// # Example
 ///
-/// ```
+/// ```rust,no_run
 /// use std::io::Read;
 /// use oneio::s3_reader;
 ///
 /// let bucket = "my_bucket";
 /// let path = "path/to/file.txt";
 ///
-/// let mut  reader = s3_reader(bucket, path)?;
+/// let mut  reader = s3_reader(bucket, path).unwrap();
 ///
 /// let mut buffer = Vec::new();
-/// reader.read_to_end(&mut buffer)?;
+/// reader.read_to_end(&mut buffer).unwrap();
 ///
 /// assert_eq!(buffer, b"File content in S3 bucket");
 /// ```
@@ -191,7 +191,7 @@ pub fn s3_reader(bucket: &str, path: &str) -> Result<Box<dyn Read + Send>, OneIo
 ///
 /// # Examples
 ///
-/// ```
+/// ```rust,no_run
 /// use oneio::s3_upload;
 ///
 /// let result = s3_upload("my-bucket", "path/to/file.txt", "/path/to/local_file.txt");
@@ -327,7 +327,7 @@ pub fn s3_download(bucket: &str, s3_path: &str, file_path: &str) -> Result<(), O
 ///
 /// ## Example
 ///
-/// ```no_run
+/// ```rust,no_run
 /// use oneio::s3_stats;
 ///
 /// let bucket = "my-bucket";

--- a/src/oneio/utils.rs
+++ b/src/oneio/utils.rs
@@ -66,16 +66,17 @@ pub fn read_json_struct<T: serde::de::DeserializeOwned>(path: &str) -> Result<T,
 /// # Example
 ///
 /// ```rust,no_run
-/// use std::io::{BufRead, BufReader, Lines, Read};
-/// use std::fs::File;
-/// use std::io::Error as OneIoError;
-/// use oneio::get_reader;
+/// use std::io::BufRead;
+/// use std::io::BufReader;
+/// const TEST_TEXT: &str = "OneIO test file.
+/// This is a test.";
 ///
-/// pub fn read_lines(path: &str) -> Result<Lines<BufReader<Box<dyn Read + Send>>>, OneIoError> {
-///     let reader = get_reader(path)?;
-///     let buf_reader = BufReader::new(reader);
-///     Ok(buf_reader.lines())
-/// }
+/// let lines = oneio::read_lines("https://spaces.bgpkit.org/oneio/test_data.txt.gz").unwrap()
+///     .map(|line| line.unwrap()).collect::<Vec<String>>();
+///
+/// assert_eq!(lines.len(), 2);
+/// assert_eq!(lines[0].as_str(), "OneIO test file.");
+/// assert_eq!(lines[1].as_str(), "This is a test.");
 /// ```
 pub fn read_lines(path: &str) -> Result<Lines<BufReader<Box<dyn Read + Send>>>, OneIoError> {
     let reader = get_reader(path)?;


### PR DESCRIPTION
Move S3-related comamnds into a subcommand under `oneio s3 ...`.

```
➜  oneio git:(s3-subcommands) ✗ cargo run --release --features cli -- s3 --help
   Compiling oneio v0.15.8 (/Users/mingwei/Git/bgpkit-git/oneio)
    Finished release [optimized] target(s) in 3.33s
     Running `target/release/oneio s3 --help`
S3-related subcommands

Usage: oneio s3 <COMMAND>

Commands:
  upload  Upload file to S3
  list    List S3 bucket
  help    Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```

Also added a new `dirs` flag to the `s3_list` function to allow listing for only directories. This is useful for directories walking on large buckets.