### PR TITLE
switch to rustls for tls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,8 @@ jobs:
           # (required) Comma-separated list of binary names (non-extension portion of filename) to build and upload.
           # Note that glob pattern is not supported yet.
           bin: oneio
-          features: cli,vendored-openssl
+          features: cli
+          checksum: sha256
           # (optional) Target triple, default is host triple.
           target: ${{ matrix.target }}
           # (required) GitHub token for uploading assets to GitHub Releases.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,10 +24,10 @@ jobs:
         run: cargo build --no-default-features
 
       - name: Build lib with native-tls
-        run: cargo build --features lib-native-tls
+        run: cargo build --no-default-features --features lib-core,native-tls
 
       - name: Build lib with rustls
-        run: cargo build --features lib-rustls
+        run: cargo build --no-default-features --features lib-core,rustls
 
       - name: Build lib with all features
         run: cargo build --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ xz2 = {version = "0.1", optional = true }
 
 # cli
 clap = {version= "4.4", features=["derive"], optional=true}
-tracing = {version="0.1.37", optional=true}
+tracing = {version="0.1", optional=true}
 
 # json
 serde = {version="1.0", optional=true }
@@ -39,23 +39,28 @@ serde_json = {version="1.0", optional=true }
 
 # s3
 rust-s3 = {version="0.34.0-rc4", optional=true, default-features=false, features=["sync"]}
-dotenvy = {version="0.15.7", optional=true}
+dotenvy = {version="0.15", optional=true}
 
 # ftp
 suppaftp = { version = "^5.1.0", optional = true }
 
 thiserror = "1.0"
 
-openssl = { version = "0.10", features = ["vendored"], optional = true }
-
 [features]
-default = ["lib"]
-all = ["lib", "cli", "s3"]
-lib = ["remote", "compressions", "json", "lib-native-tls"]
+# default features include the library core and use rustls by default
+default = ["lib-core", "rustls"]
 
-# choice between native TLS or rustls
-lib-native-tls = ["native-tls"]
-lib-rustls = ["rustls"]
+# library core dependency to enable reading from local/remote with compressions enabled
+lib-core = ["remote", "compressions", "json"]
+
+# cli dependencies
+cli = [
+    # core dependency
+    "lib-core", "rustls", "s3",
+    # CLI specific
+    "clap", "tracing",
+]
+
 # optional flags to select native-tls or rust-tls
 native-tls = ["reqwest?/default-tls", "suppaftp?/native-tls", "rust-s3?/sync-native-tls"]
 rustls = ["reqwest?/rustls-tls", "suppaftp?/rustls", "rust-s3?/sync-rustls-tls"]
@@ -68,17 +73,10 @@ lz = ["lz4"]
 xz = ["xz2"]
 
 remote=["reqwest", "suppaftp"]
-cli = ["clap", "tracing", "s3", "no-cache"]
 json = ["serde", "serde_json"]
 
 # s3 support, off by default
-s3= ["rust-s3", "native-tls", "dotenvy"]
-
-# no-cache
-no-cache = []
-
-# vendored openssl
-vendored-openssl = ["openssl"]
+s3= ["rust-s3", "dotenvy"]
 
 [dev-dependencies]
 serde = {version="1.0", features=["derive"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ cli = [
 native-tls = ["reqwest?/default-tls", "suppaftp?/native-tls", "rust-s3?/sync-native-tls"]
 rustls = ["reqwest?/rustls-tls", "suppaftp?/rustls", "rust-s3?/sync-rustls-tls"]
 
-# supported compression algorithms, can be tuggled on/off individually
+# supported compression algorithms, which can be toggled on/off individually
 compressions = ["gz", "bz", "lz", "xz"]
 gz = ["libflate"]
 bz = ["bzip2"]

--- a/src/bin/oneio.rs
+++ b/src/bin/oneio.rs
@@ -8,7 +8,7 @@ use std::process::exit;
 #[clap(author, version)]
 #[clap(propagate_version = true)]
 #[command(arg_required_else_help(true))]
-/// oneio attempts to read files from local or remote locations with any compression.
+/// oneio reads files from local or remote locations with any compression.
 struct Cli {
     /// file to open, remote or local
     #[clap(name = "FILE")]

--- a/src/oneio/remote.rs
+++ b/src/oneio/remote.rs
@@ -40,7 +40,7 @@ fn get_remote_http_raw(
         reqwest::header::USER_AGENT,
         reqwest::header::HeaderValue::from_static("oneio"),
     );
-    #[cfg(feature = "no-cache")]
+    #[cfg(feature = "cli")]
     headers.insert(
         reqwest::header::CACHE_CONTROL,
         reqwest::header::HeaderValue::from_static("no-cache"),


### PR DESCRIPTION
## Changes

- remove `vendored-openssl` feature and `openssl` dependency
- remove `no-cache` feature
- default to `rustls` for default tls library
- clean up feature flags