### PR TITLE
add sha256sum digest functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,10 @@ bzip2 = {version = "0.4.4", optional = true }
 lz4 = {version = "1.24", optional = true }
 xz2 = {version = "0.1", optional = true }
 
+# sha256
+ring = { version = "0.17", optional = true }
+hex = {version = "0.4", optional = true}
+
 # cli
 clap = {version= "4.4", features=["derive"], optional=true}
 tracing = {version="0.1", optional=true}
@@ -51,7 +55,7 @@ thiserror = "1.0"
 default = ["lib-core", "rustls"]
 
 # library core dependency to enable reading from local/remote with compressions enabled
-lib-core = ["remote", "compressions", "json"]
+lib-core = ["remote", "compressions", "json", "digest"]
 
 # cli dependencies
 cli = [
@@ -64,6 +68,8 @@ cli = [
 # optional flags to select native-tls or rust-tls
 native-tls = ["reqwest?/default-tls", "suppaftp?/native-tls", "rust-s3?/sync-native-tls"]
 rustls = ["reqwest?/rustls-tls", "suppaftp?/rustls", "rust-s3?/sync-rustls-tls"]
+
+digest = ["ring", "hex"]
 
 # supported compression algorithms, which can be toggled on/off individually
 compressions = ["gz", "bz", "lz", "xz"]

--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ Default flags include `lib-core` and `rustls`.
 
 Users can choose between `rustls` or `native-tls` as their TLS library. We use `rustls` as the basic library.
 
-### Optional features: `cli`, `s3`
+### Optional features: `cli`, `s3`, `digest`
 
 - `s3`: allow reading from AWS S3 compatible buckets
 - `cli`: build commandline program `oneio`, uses the following features
   - `lib-core`, `rustls`, `s3` for core functionalities
   - `clap`, `tracing` for CLI basics
+- `digest` for generating SHA256 digest string
 
 ## Use `oneio` commandline tool
 

--- a/src/bin/oneio.rs
+++ b/src/bin/oneio.rs
@@ -49,6 +49,13 @@ enum Commands {
         #[clap(subcommand)]
         s3_command: S3Commands,
     },
+
+    /// Generate SHA256 digest
+    Digest {
+        /// file to open, remote or local
+        #[clap(name = "FILE")]
+        file: PathBuf,
+    },
 }
 
 #[derive(Subcommand)]
@@ -100,8 +107,11 @@ fn main() {
                         exit(1);
                     }
                     let path_string = cli.file.clone().unwrap().to_str().unwrap().to_string();
-                    let path = path_string.as_str();
-                    match oneio::s3_upload(s3_bucket.as_str(), s3_path.as_str(), path) {
+                    match oneio::s3_upload(
+                        s3_bucket.as_str(),
+                        s3_path.as_str(),
+                        path_string.as_str(),
+                    ) {
                         Ok(_) => {
                             println!(
                                 "file successfully uploaded to s3://{}/{}",
@@ -138,6 +148,14 @@ fn main() {
                     return;
                 }
             },
+            Commands::Digest { file } => {
+                let path_string = file.as_path().to_string_lossy().to_string();
+                println!(
+                    "{}",
+                    oneio::get_sha256_digest(path_string.as_str()).unwrap()
+                );
+                return;
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,8 +134,11 @@ mod oneio;
 
 pub use error::OneIoError;
 
+#[cfg(feature = "digest")]
+pub use crate::oneio::digest::*;
 #[cfg(feature = "remote")]
 pub use crate::oneio::remote::*;
 #[cfg(feature = "s3")]
 pub use crate::oneio::s3::*;
+
 pub use crate::oneio::*;

--- a/src/oneio/digest.rs
+++ b/src/oneio/digest.rs
@@ -1,0 +1,38 @@
+//! This module contains functions to calculate the digest of a file.
+//!
+//! The digest is calculated using the SHA256 algorithm.
+
+use crate::{get_reader, OneIoError};
+use ring::digest::{Context, SHA256};
+
+/// Calculate the SHA256 digest of a file.
+///
+/// This function takes a path to a file as input and returns the SHA256 digest of the file
+/// as a hexadecimal string.
+///
+/// # Arguments
+///
+/// * `Path` - A string slice that holds the path to the file.
+///
+/// # Errors
+///
+/// This function can return an error of type `OneIoError` if there is an issue while reading the file.
+/// The error can occur if the file doesn't exist, if there are permission issues, or if there are
+/// issues with the underlying I/O operations.
+pub fn get_sha256_digest(path: &str) -> Result<String, OneIoError> {
+    let mut context = Context::new(&SHA256);
+    let mut buffer = [0; 1024];
+
+    let mut reader = get_reader(path)?;
+    loop {
+        let count = reader.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        context.update(&buffer[..count]);
+    }
+
+    let digest = context.finish();
+
+    Ok(hex::encode(digest.as_ref()))
+}

--- a/src/oneio/mod.rs
+++ b/src/oneio/mod.rs
@@ -2,10 +2,13 @@
 mod compressions;
 #[cfg(feature = "compressions")]
 use crate::oneio::compressions::OneIOCompression;
+#[cfg(feature = "digest")]
+pub mod digest;
 #[cfg(feature = "remote")]
 pub mod remote;
 #[cfg(feature = "s3")]
 pub mod s3;
+
 pub mod utils;
 
 pub use utils::*;


### PR DESCRIPTION
## changes
- added `get_sha256_digest` function to `oneio` main library
- add `oneio digest` subcommand to read a local/remote file and calculate the sha256 digest


Fixes #40 