### PR TITLE
Add `exists` function to library

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,8 +3,12 @@ name: Rust
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,16 +28,16 @@ jobs:
         run: cargo build --no-default-features
 
       - name: Build lib with native-tls
-        run: cargo build --no-default-features --features lib-core,native-tls
+        run: cargo build --no-default-features --features lib-core,native-tls && cargo tree --no-default-features --features lib-core,native-tls | grep -q rustls && {exit 1} || echo "success"
 
       - name: Build lib with rustls
-        run: cargo build --no-default-features --features lib-core,rustls
+        run: cargo build --no-default-features --features lib-core,rustls && cargo tree --no-default-features --features lib-core,rustls | grep -q native-tls && {exit 1} || echo "success"
 
       - name: Build lib with all features
         run: cargo build --all-features
 
-      - name: Run test for lib + s3 features (s3 for doc compilation tests)
-        run: cargo test --features s3
+      - name: Run test for lib + all optionals features
+        run: cargo test --all-features
 
       - name: Run format check
         run: cargo fmt --check

--- a/src/oneio/mod.rs
+++ b/src/oneio/mod.rs
@@ -169,3 +169,29 @@ pub fn get_writer(path: &str) -> Result<Box<dyn Write>, OneIoError> {
         _ => Ok(Box::new(BufWriter::new(output_file))),
     }
 }
+
+/// Check if a file or directory exists.
+///
+/// This function takes a path as an argument and returns a `Result` indicating whether the file or directory at the given path exists or not.
+///
+/// # Examples
+///
+/// ```rust
+/// use crate::oneio::exists;
+///
+/// match exists("path/to/file.txt") {
+///     Ok(true) => println!("File exists."),
+///     Ok(false) => println!("File does not exist."),
+///     Err(error) => eprintln!("An error occurred: {}", error),
+/// }
+/// ```
+///
+/// # Errors
+///
+/// This function may return an `OneIoError` if there is an error accessing the file system or if the `remote` feature is enabled and there is an error
+pub fn exists(path: &str) -> Result<bool, OneIoError> {
+    #[cfg(feature = "remote")]
+    return remote::remote_file_exists(path);
+    #[cfg(not(feature = "remote"))]
+    Ok(std::path::Path::new(path).exists())
+}

--- a/tests/oneio_test.rs
+++ b/tests/oneio_test.rs
@@ -155,6 +155,9 @@ fn test_read_json_struct() {
 fn test_read_404() {
     let reader = oneio::get_reader("https://spaces.bgpkit.org/oneio/test_data_NOT_EXIST.json");
     assert!(reader.is_err());
+    assert!(!oneio::exists("https://spaces.bgpkit.org/oneio/test_data_NOT_EXIST.json").unwrap());
+
     let reader = oneio::get_reader("https://spaces.bgpkit.org/oneio/test_data.json");
     assert!(reader.is_ok());
+    assert!(oneio::exists("https://spaces.bgpkit.org/oneio/test_data.json").unwrap());
 }


### PR DESCRIPTION
### Highlight

* add `oneio::exists(path: &str)` function to check if a local or remote file exists.
  * currently support local file, http(s) remote and s3 remote files checking

### Example usages
```rust
    assert!(!oneio::exists("https://spaces.bgpkit.org/oneio/test_data_NOT_EXIST.json").unwrap());
    assert!(oneio::exists("https://spaces.bgpkit.org/oneio/test_data.json").unwrap());
```