### PR TITLE
switch to zlib-ng for gzip file handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,35 +15,35 @@ default-run = "oneio"
 keywords = ["io", "util", "s3", "ftp"]
 
 [[bin]]
-name="oneio"
-path="src/bin/oneio.rs"
-required-features=["cli"]
+name = "oneio"
+path = "src/bin/oneio.rs"
+required-features = ["cli"]
 
 [dependencies]
 # remote
-reqwest = {version="0.11", default-features=false, features = ["blocking"], optional=true }
+reqwest = { version = "0.11", default-features = false, features = ["blocking"], optional = true }
 
 # compression
-libflate = {version = "2", optional=true }
-bzip2 = {version = "0.4.4", optional = true }
-lz4 = {version = "1.24", optional = true }
-xz2 = {version = "0.1", optional = true }
+flate2 = { version = "1", default-features = false, features = ["zlib-ng"], optional = true }
+bzip2 = { version = "0.4.4", optional = true }
+lz4 = { version = "1.24", optional = true }
+xz2 = { version = "0.1", optional = true }
 
 # sha256
 ring = { version = "0.17", optional = true }
-hex = {version = "0.4", optional = true}
+hex = { version = "0.4", optional = true }
 
 # cli
-clap = {version= "4.4", features=["derive"], optional=true}
-tracing = {version="0.1", optional=true}
+clap = { version = "4.4", features = ["derive"], optional = true }
+tracing = { version = "0.1", optional = true }
 
 # json
-serde = {version="1.0", optional=true }
-serde_json = {version="1.0", optional=true }
+serde = { version = "1.0", optional = true }
+serde_json = { version = "1.0", optional = true }
 
 # s3
-rust-s3 = {version="0.34.0-rc4", optional=true, default-features=false, features=["sync"]}
-dotenvy = {version="0.15", optional=true}
+rust-s3 = { version = "0.34.0-rc4", optional = true, default-features = false, features = ["sync"] }
+dotenvy = { version = "0.15", optional = true }
 
 # ftp
 suppaftp = { version = "^5.1.0", optional = true }
@@ -73,19 +73,19 @@ digest = ["ring", "hex"]
 
 # supported compression algorithms, which can be toggled on/off individually
 compressions = ["gz", "bz", "lz", "xz"]
-gz = ["libflate"]
+gz = ["flate2"]
 bz = ["bzip2"]
 lz = ["lz4"]
 xz = ["xz2"]
 
-remote=["reqwest", "suppaftp"]
+remote = ["reqwest", "suppaftp"]
 json = ["serde", "serde_json"]
 
 # s3 support, off by default
-s3= ["rust-s3", "dotenvy"]
+s3 = ["rust-s3", "dotenvy"]
 
 [dev-dependencies]
-serde = {version="1.0", features=["derive"]}
+serde = { version = "1.0", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 tar = "0.4"

--- a/src/oneio/compressions/gzip.rs
+++ b/src/oneio/compressions/gzip.rs
@@ -1,8 +1,8 @@
 use crate::oneio::compressions::OneIOCompression;
 use crate::OneIoError;
-use libflate::finish::AutoFinishUnchecked;
-use libflate::gzip::Decoder;
-use libflate::gzip::Encoder;
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use flate2::Compression;
 use std::fs::File;
 use std::io::{BufWriter, Read, Write};
 
@@ -10,12 +10,12 @@ pub(crate) struct OneIOGzip;
 
 impl OneIOCompression for OneIOGzip {
     fn get_reader(raw_reader: Box<dyn Read + Send>) -> Result<Box<dyn Read + Send>, OneIoError> {
-        Ok(Box::new(Decoder::new(raw_reader)?))
+        Ok(Box::new(GzDecoder::new(raw_reader)))
     }
 
     fn get_writer(raw_writer: BufWriter<File>) -> Result<Box<dyn Write>, OneIoError> {
         // see libflate docs on the reasons of using [AutoFinishUnchecked].
-        let encoder = AutoFinishUnchecked::new(Encoder::new(raw_writer)?);
+        let encoder = GzEncoder::new(raw_writer, Compression::default());
         Ok(Box::new(encoder))
     }
 }


### PR DESCRIPTION
`zlib-ng` is significantly faster than `flate2`'s default Rust implementation or `libflate`'s.