### PR TITLE
switch flate2 back to rust backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,10 @@ required-features = ["cli"]
 
 [dependencies]
 # remote
-reqwest = { version = "0.11", default-features = false, features = ["blocking"], optional = true }
+reqwest = { version = "0.12", default-features = false, features = ["blocking"], optional = true }
 
 # compression
-flate2 = { version = "1", default-features = false, features = ["zlib-ng"], optional = true }
+flate2 = { version = "1", optional = true }
 bzip2 = { version = "0.4.4", optional = true }
 lz4 = { version = "1.24", optional = true }
 xz2 = { version = "0.1", optional = true }

--- a/tests/oneio_test.rs
+++ b/tests/oneio_test.rs
@@ -1,5 +1,4 @@
 use oneio;
-use std::collections::HashMap;
 use std::io::Write;
 
 const TEST_TEXT: &str = "OneIO test file.
@@ -98,17 +97,6 @@ fn test_reader_remote() {
     test_read("https://spaces.bgpkit.org/oneio/test_data.txt.bz2");
     test_read("https://spaces.bgpkit.org/oneio/test_data.txt.lz4");
     test_read("https://spaces.bgpkit.org/oneio/test_data.txt.xz");
-}
-
-#[test]
-fn test_reader_remote_with_header() {
-    let mut reader = oneio::get_remote_reader(
-        "https://bgp-datasets.radar-cfdata-org.workers.dev/caida/as2org/20050801.as-org2info.jsonl.gz",
-        HashMap::from([("X-Custom-Auth-Key".to_string(), "vDe94ID5qAHC5YMtHdHexoyk7".to_string())])
-    ).unwrap();
-
-    let mut text = "".to_string();
-    reader.read_to_string(&mut text).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
### Highlights

- switch `flate2` dependency back to the default Rust backend
- update `rewest` to `0.12`
