### PR TITLE
[feature] allow specifying custom reqwest client

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,11 +204,20 @@ fn main() {
 
 ```rust
 use std::collections::HashMap;
+use std::collections::HashMap;
+use reqwest::header::HeaderMap;
 
 fn main() {
-    let mut reader = oneio::get_remote_reader(
+    let headers: HeaderMap = (&HashMap::from([("X-Custom-Auth-Key".to_string(), "TOKEN".to_string())]))
+        .try_into().expect("invalid headers");
+
+    let client = reqwest::blocking::Client::builder()
+        .default_headers(headers)
+        .danger_accept_invalid_certs(true)
+        .build().unwrap();
+    let mut reader = oneio::get_http_reader(
         "https://SOME_REMOTE_RESOURCE_PROTECTED_BY_ACCESS_TOKEN",
-        HashMap::from([("X-Custom-Auth-Key".to_string(), "TOKEN".to_string())])
+        Some(client),
     ).unwrap();
     let mut text = "".to_string();
     reader.read_to_string(&mut text).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,9 +83,14 @@
 //! Read remote content with custom headers
 //! ```no_run
 //! use std::collections::HashMap;
-//! let mut reader = oneio::get_remote_reader(
+//! use reqwest::header::HeaderMap;
+//! let headers: HeaderMap = (&HashMap::from([("X-Custom-Auth-Key".to_string(), "TOKEN".to_string())])).try_into().expect("invalid headers");
+//! let client = reqwest::blocking::Client::builder()
+//!        .default_headers(headers)
+//!        .build().unwrap();
+//! let mut reader = oneio::get_http_reader(
 //!   "https://SOME_REMOTE_RESOURCE_PROTECTED_BY_ACCESS_TOKEN",
-//!   HashMap::from([("X-Custom-Auth-Key".to_string(), "TOKEN".to_string())])
+//!   Some(client),
 //! ).unwrap();
 //! let mut text = "".to_string();
 //! reader.read_to_string(&mut text).unwrap();

--- a/src/oneio/mod.rs
+++ b/src/oneio/mod.rs
@@ -18,7 +18,7 @@ use std::fs::File;
 use std::io::{BufWriter, Read, Write};
 use std::path::Path;
 
-fn get_writer_raw(path: &str) -> Result<BufWriter<File>, OneIoError> {
+pub fn get_writer_raw(path: &str) -> Result<BufWriter<File>, OneIoError> {
     let path = Path::new(path);
     if let Some(prefix) = path.parent() {
         std::fs::create_dir_all(prefix)?;
@@ -27,7 +27,7 @@ fn get_writer_raw(path: &str) -> Result<BufWriter<File>, OneIoError> {
     Ok(output_file)
 }
 
-fn get_reader_raw(path: &str) -> Result<Box<dyn Read + Send>, OneIoError> {
+pub fn get_reader_raw(path: &str) -> Result<Box<dyn Read + Send>, OneIoError> {
     #[cfg(feature = "remote")]
     let raw_reader: Box<dyn Read + Send> = remote::get_reader_raw_remote(path)?;
     #[cfg(not(feature = "remote"))]


### PR DESCRIPTION
This PR allows oneio::get_http_reader function to take an optional opt_client instead of headers, allowing more flexibility on customizing HTTP reqwest instead of only allowing changing headers.

It is now library users' responsibility to create custom `reqwest::blocking::Client` for any request customizations.

This PR has a couple of breaking changes:
1. rename `oneio::get_remote_reader` to `oneio::get_http_reader`
2. rename `get_remote_ftp_raw` to `get_ftp_reader_raw`
3. change signatures of `oneio::download`, `oneio::download_with_retry`, `oneio::get_http_reader`'s optional HashMap parameter for headers to optional `reqwest::blocking::Client`.

This PR resolves issue #52 