### PR TITLE
Change Credentials::from_env to Credentials::new

### DIFF
--- a/src/oneio/s3.rs
+++ b/src/oneio/s3.rs
@@ -127,7 +127,7 @@ pub fn s3_bucket(bucket: &str) -> Result<Bucket, OneIoError> {
     let mut bucket = Bucket::new(
         bucket,
         Region::from_default_env()?,
-        Credentials::from_env()?,
+        Credentials::new(None, None, None, None, None)?,
     )?;
     bucket.set_request_timeout(Some(std::time::Duration::from_secs(10 * 60)));
     Ok(bucket)


### PR DESCRIPTION
Doing so will still allow setting them using env vars, but it also tries getting them from additional sources (which is useful when running on ECS, EC2, etc.):

See the implementation of `Credentials::new` at:
https://github.com/durch/rust-s3/blob/7182a4f85d576013b3ab553fddf3656344d7e477/aws-creds/src/credentials.rs#L301C9-L306C58

```
Credentials::from_sts_env("aws-creds")
            .or_else(|_| Credentials::from_env())
            .or_else(|_| Credentials::from_profile(profile))
            .or_else(|_| Credentials::from_instance_metadata_v2(false))
            .or_else(|_| Credentials::from_instance_metadata(false))
            .map_err(|_| CredentialsError::NoCredentials)
```