### PR TITLE
refactor: improve feature flag handling and add compression utilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ lib-core = ["remote", "compressions", "json"]
 # remote IO features
 remote = ["http", "ftp"]
 http = ["reqwest"]
-ftp = ["suppaftp"]
+ftp = ["http", "suppaftp"] # ftp also requires http feature on purpose
 
 # cli dependencies
 cli = [

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,16 @@
+fn main() {
+    let http = std::env::var("CARGO_FEATURE_HTTP").is_ok();
+    let ftp = std::env::var("CARGO_FEATURE_FTP").is_ok();
+    let remote = std::env::var("CARGO_FEATURE_REMOTE").is_ok();
+    let rustls = std::env::var("CARGO_FEATURE_RUSTLS").is_ok();
+    let native_tls = std::env::var("CARGO_FEATURE_NATIVE_TLS").is_ok();
+
+    let needs_tls = http || ftp || remote;
+    let has_tls = rustls || native_tls;
+
+    if needs_tls && !has_tls {
+        panic!(
+            "Feature `http`, `ftp`, or `remote` requires at least one of `rustls` or `native-tls` features to be enabled."
+        );
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,10 +2,10 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum OneIoError {
-    #[cfg(feature = "remote")]
+    #[cfg(feature = "http")]
     #[error("remote IO error: {0}")]
     RemoteIoError(#[from] reqwest::Error),
-    #[cfg(feature = "remote")]
+    #[cfg(feature = "ftp")]
     #[error("FTP error: {0}")]
     FptError(#[from] suppaftp::FtpError),
     #[cfg(feature = "json")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,4 +296,6 @@ pub use crate::oneio::remote::*;
 #[cfg(feature = "s3")]
 pub use crate::oneio::s3::*;
 
+pub use crate::oneio::utils::*;
+
 pub use crate::oneio::*;

--- a/src/oneio/compressions/bzip2.rs
+++ b/src/oneio/compressions/bzip2.rs
@@ -1,3 +1,8 @@
+//! Bzip2 compression support for OneIO.
+//!
+//! This module provides the [`OneIOBzip2`] struct, which implements the [`OneIOCompression`] trait
+//! for reading and writing bzip2-compressed files.
+
 use crate::oneio::compressions::OneIOCompression;
 use crate::OneIoError;
 use bzip2::read::BzDecoder;
@@ -9,10 +14,26 @@ use std::io::{BufWriter, Read, Write};
 pub(crate) struct OneIOBzip2;
 
 impl OneIOCompression for OneIOBzip2 {
+    /// Returns a reader that decompresses bzip2-compressed data from the given reader.
+    ///
+    /// # Arguments
+    /// * `raw_reader` - A boxed reader containing bzip2-compressed data.
+    ///
+    /// # Returns
+    /// * `Ok(Box<dyn Read + Send>)` - A reader that decompresses bzip2 data on the fly.
+    /// * `Err(OneIoError)` - If the bzip2 decoder could not be created.
     fn get_reader(raw_reader: Box<dyn Read + Send>) -> Result<Box<dyn Read + Send>, OneIoError> {
         Ok(Box::new(BzDecoder::new(raw_reader)))
     }
 
+    /// Returns a writer that compresses data to bzip2 format.
+    ///
+    /// # Arguments
+    /// * `raw_writer` - A buffered writer for the target file.
+    ///
+    /// # Returns
+    /// * `Ok(Box<dyn Write>)` - A writer that compresses data to bzip2 format.
+    /// * `Err(OneIoError)` - If the bzip2 encoder could not be created.
     fn get_writer(raw_writer: BufWriter<File>) -> Result<Box<dyn Write>, OneIoError> {
         Ok(Box::new(BzEncoder::new(raw_writer, Compression::default())))
     }

--- a/src/oneio/compressions/gzip.rs
+++ b/src/oneio/compressions/gzip.rs
@@ -1,3 +1,8 @@
+//! Gzip compression support for OneIO.
+//!
+//! This module provides the [`OneIOGzip`] struct, which implements the [`OneIOCompression`] trait
+//! for reading and writing gzip-compressed files.
+
 use crate::oneio::compressions::OneIOCompression;
 use crate::OneIoError;
 use flate2::read::GzDecoder;
@@ -9,10 +14,26 @@ use std::io::{BufWriter, Read, Write};
 pub(crate) struct OneIOGzip;
 
 impl OneIOCompression for OneIOGzip {
+    /// Returns a reader that decompresses gzip-compressed data from the given reader.
+    ///
+    /// # Arguments
+    /// * `raw_reader` - A boxed reader containing gzip-compressed data.
+    ///
+    /// # Returns
+    /// * `Ok(Box<dyn Read + Send>)` - A reader that decompresses gzip data on the fly.
+    /// * `Err(OneIoError)` - If the gzip decoder could not be created.
     fn get_reader(raw_reader: Box<dyn Read + Send>) -> Result<Box<dyn Read + Send>, OneIoError> {
         Ok(Box::new(GzDecoder::new(raw_reader)))
     }
 
+    /// Returns a writer that compresses data to gzip format.
+    ///
+    /// # Arguments
+    /// * `raw_writer` - A buffered writer for the target file.
+    ///
+    /// # Returns
+    /// * `Ok(Box<dyn Write>)` - A writer that compresses data to gzip format.
+    /// * `Err(OneIoError)` - If the gzip encoder could not be created.
     fn get_writer(raw_writer: BufWriter<File>) -> Result<Box<dyn Write>, OneIoError> {
         // see libflate docs on the reasons of using [AutoFinishUnchecked].
         let encoder = GzEncoder::new(raw_writer, Compression::default());

--- a/src/oneio/compressions/lz4.rs
+++ b/src/oneio/compressions/lz4.rs
@@ -1,3 +1,8 @@
+//! LZ4 compression support for OneIO.
+//!
+//! This module provides the [`OneIOLz4`] struct, which implements the [`OneIOCompression`] trait
+//! for reading lz4-compressed files. Writing lz4-compressed files is not currently supported.
+
 use crate::oneio::compressions::OneIOCompression;
 use crate::OneIoError;
 use lz4::Decoder;
@@ -7,10 +12,25 @@ use std::io::{BufWriter, Read, Write};
 pub(crate) struct OneIOLz4;
 
 impl OneIOCompression for OneIOLz4 {
+    /// Returns a reader that decompresses lz4-compressed data from the given reader.
+    ///
+    /// # Arguments
+    /// * `raw_reader` - A boxed reader containing lz4-compressed data.
+    ///
+    /// # Returns
+    /// * `Ok(Box<dyn Read + Send>)` - A reader that decompresses lz4 data on the fly.
+    /// * `Err(OneIoError)` - If the lz4 decoder could not be created.
     fn get_reader(raw_reader: Box<dyn Read + Send>) -> Result<Box<dyn Read + Send>, OneIoError> {
         Ok(Box::new(Decoder::new(raw_reader).unwrap()))
     }
 
+    /// Returns an error because lz4 writer is not currently supported.
+    ///
+    /// # Arguments
+    /// * `_raw_writer` - A buffered writer for the target file (unused).
+    ///
+    /// # Returns
+    /// * `Err(OneIoError)` - Always returns an error indicating lz4 writer is not supported.
     fn get_writer(_raw_writer: BufWriter<File>) -> Result<Box<dyn Write>, OneIoError> {
         Err(OneIoError::NotSupported(
             "lz4 writer is not currently supported.".to_string(),

--- a/src/oneio/compressions/mod.rs
+++ b/src/oneio/compressions/mod.rs
@@ -1,3 +1,12 @@
+//! Compression algorithms and utilities for OneIO.
+//!
+//! This module provides a unified interface for reading and writing files with various compression
+//! formats, including gzip, bzip2, lz4, xz, and zstd. The available algorithms depend on enabled
+//! Cargo features. Each compression algorithm implements the [`OneIOCompression`] trait, which
+//! defines methods for creating readers and writers that transparently handle compression and
+//! decompression. Utility functions are provided to select the appropriate algorithm based on file
+//! suffixes.
+
 use crate::OneIoError;
 use std::fs::File;
 use std::io::{BufWriter, Read, Write};

--- a/src/oneio/compressions/mod.rs
+++ b/src/oneio/compressions/mod.rs
@@ -17,3 +17,45 @@ pub trait OneIOCompression {
     fn get_reader(raw_reader: Box<dyn Read + Send>) -> Result<Box<dyn Read + Send>, OneIoError>;
     fn get_writer(raw_writer: BufWriter<File>) -> Result<Box<dyn Write>, OneIoError>;
 }
+
+/// Returns a reader for the given file path, handling compression based on the file type.
+pub(crate) fn get_compression_reader(
+    raw_reader: Box<dyn Read + Send>,
+    file_suffix: &str,
+) -> Result<Box<dyn Read + Send>, OneIoError> {
+    match file_suffix {
+        #[cfg(feature = "gz")]
+        "gz" | "gzip" | "tgz" => gzip::OneIOGzip::get_reader(raw_reader),
+        #[cfg(feature = "bz")]
+        "bz2" | "bz" => bzip2::OneIOBzip2::get_reader(raw_reader),
+        #[cfg(feature = "lz")]
+        "lz4" | "lz" => lz4::OneIOLz4::get_reader(raw_reader),
+        #[cfg(feature = "xz")]
+        "xz" | "xz2" | "lzma" => xz::OneIOXz::get_reader(raw_reader),
+        #[cfg(feature = "zstd")]
+        "zst" | "zstd" => zstd::OneIOZstd::get_reader(raw_reader),
+        _ => {
+            // unknown file type of file {}. return the raw bytes reader as is
+            Ok(raw_reader)
+        }
+    }
+}
+
+pub(crate) fn get_compression_writer(
+    raw_writer: BufWriter<File>,
+    file_suffix: &str,
+) -> Result<Box<dyn Write>, OneIoError> {
+    match file_suffix {
+        #[cfg(feature = "gz")]
+        "gz" | "gzip" | "tgz" => gzip::OneIOGzip::get_writer(raw_writer),
+        #[cfg(feature = "bz")]
+        "bz2" | "bz" => bzip2::OneIOBzip2::get_writer(raw_writer),
+        #[cfg(feature = "lz")]
+        "lz4" | "lz" => lz4::OneIOLz4::get_writer(raw_writer),
+        #[cfg(feature = "xz")]
+        "xz" | "xz2" | "lzma" => xz::OneIOXz::get_writer(raw_writer),
+        #[cfg(feature = "zstd")]
+        "zst" | "zstd" => zstd::OneIOZstd::get_writer(raw_writer),
+        _ => Ok(Box::new(raw_writer)),
+    }
+}

--- a/src/oneio/compressions/xz.rs
+++ b/src/oneio/compressions/xz.rs
@@ -1,3 +1,8 @@
+//! XZ compression support for OneIO.
+//!
+//! This module provides the [`OneIOXz`] struct, which implements the [`OneIOCompression`] trait
+//! for reading and writing xz-compressed files.
+
 use crate::oneio::compressions::OneIOCompression;
 use crate::OneIoError;
 use std::fs::File;
@@ -8,10 +13,26 @@ use xz2::write::XzEncoder;
 pub(crate) struct OneIOXz;
 
 impl OneIOCompression for OneIOXz {
+    /// Returns a reader that decompresses xz-compressed data from the given reader.
+    ///
+    /// # Arguments
+    /// * `raw_reader` - A boxed reader containing xz-compressed data.
+    ///
+    /// # Returns
+    /// * `Ok(Box<dyn Read + Send>)` - A reader that decompresses xz data on the fly.
+    /// * `Err(OneIoError)` - If the xz decoder could not be created.
     fn get_reader(raw_reader: Box<dyn Read + Send>) -> Result<Box<dyn Read + Send>, OneIoError> {
         Ok(Box::new(XzDecoder::new(raw_reader)))
     }
 
+    /// Returns a writer that compresses data to xz format.
+    ///
+    /// # Arguments
+    /// * `raw_writer` - A buffered writer for the target file.
+    ///
+    /// # Returns
+    /// * `Ok(Box<dyn Write>)` - A writer that compresses data to xz format.
+    /// * `Err(OneIoError)` - If the xz encoder could not be created.
     fn get_writer(raw_writer: BufWriter<File>) -> Result<Box<dyn Write>, OneIoError> {
         Ok(Box::new(XzEncoder::new(raw_writer, 9)))
     }

--- a/src/oneio/compressions/zstd.rs
+++ b/src/oneio/compressions/zstd.rs
@@ -1,3 +1,8 @@
+//! Zstandard (zstd) compression support for OneIO.
+//!
+//! This module provides the [`OneIOZstd`] struct, which implements the [`OneIOCompression`] trait
+//! for reading and writing zstd-compressed files.
+
 use crate::oneio::compressions::OneIOCompression;
 use crate::OneIoError;
 use std::fs::File;
@@ -6,6 +11,14 @@ use std::io::{BufWriter, Read, Write};
 pub(crate) struct OneIOZstd;
 
 impl OneIOCompression for OneIOZstd {
+    /// Returns a reader that decompresses zstd-compressed data from the given reader.
+    ///
+    /// # Arguments
+    /// * `raw_reader` - A boxed reader containing zstd-compressed data.
+    ///
+    /// # Returns
+    /// * `Ok(Box<dyn Read + Send>)` - A reader that decompresses zstd data on the fly.
+    /// * `Err(OneIoError)` - If the zstd decoder could not be created.
     fn get_reader(raw_reader: Box<dyn Read + Send>) -> Result<Box<dyn Read + Send>, OneIoError> {
         match zstd::Decoder::new(raw_reader) {
             Ok(dec) => Ok(Box::new(dec)),
@@ -13,6 +26,14 @@ impl OneIOCompression for OneIOZstd {
         }
     }
 
+    /// Returns a writer that compresses data to zstd format.
+    ///
+    /// # Arguments
+    /// * `raw_writer` - A buffered writer for the target file.
+    ///
+    /// # Returns
+    /// * `Ok(Box<dyn Write>)` - A writer that compresses data to zstd format.
+    /// * `Err(OneIoError)` - If the zstd encoder could not be created.
     fn get_writer(raw_writer: BufWriter<File>) -> Result<Box<dyn Write>, OneIoError> {
         match zstd::Encoder::new(raw_writer, 9) {
             Ok(dec) => Ok(Box::new(dec.auto_finish())),

--- a/src/oneio/mod.rs
+++ b/src/oneio/mod.rs
@@ -191,8 +191,9 @@ pub fn get_writer(path: &str) -> Result<Box<dyn Write>, OneIoError> {
 ///
 /// This function may return a `OneIoError` if there is an error accessing the file system or if the `remote` feature is enabled and there is an error
 pub fn exists(path: &str) -> Result<bool, OneIoError> {
-    #[cfg(any(feature = "http", feature = "ftp"))]
-    return remote::remote_file_exists(path);
-    #[cfg(not(any(feature = "http", feature = "ftp")))]
-    Ok(std::path::Path::new(path).exists())
+    if cfg!(any(feature = "http", feature = "s3")) {
+        remote::remote_file_exists(path)
+    } else {
+        Ok(Path::new(path).exists())
+    }
 }

--- a/src/oneio/mod.rs
+++ b/src/oneio/mod.rs
@@ -191,9 +191,12 @@ pub fn get_writer(path: &str) -> Result<Box<dyn Write>, OneIoError> {
 ///
 /// This function may return a `OneIoError` if there is an error accessing the file system or if the `remote` feature is enabled and there is an error
 pub fn exists(path: &str) -> Result<bool, OneIoError> {
-    if cfg!(any(feature = "http", feature = "s3")) {
-        remote::remote_file_exists(path)
-    } else {
-        Ok(Path::new(path).exists())
+    #[cfg(any(feature = "http", feature = "s3"))]
+    {
+        return remote::remote_file_exists(path);
+    }
+    #[cfg(not(any(feature = "http", feature = "s3")))]
+    {
+        return Ok(Path::new(path).exists());
     }
 }

--- a/src/oneio/mod.rs
+++ b/src/oneio/mod.rs
@@ -193,10 +193,10 @@ pub fn get_writer(path: &str) -> Result<Box<dyn Write>, OneIoError> {
 pub fn exists(path: &str) -> Result<bool, OneIoError> {
     #[cfg(any(feature = "http", feature = "s3"))]
     {
-        return remote::remote_file_exists(path);
+        remote::remote_file_exists(path)
     }
     #[cfg(not(any(feature = "http", feature = "s3")))]
     {
-        return Ok(Path::new(path).exists());
+        Ok(Path::new(path).exists())
     }
 }

--- a/src/oneio/remote.rs
+++ b/src/oneio/remote.rs
@@ -1,9 +1,8 @@
 //! This module provides functionality to handle remote file operations such as downloading files
 //! from HTTP, FTP, and S3 protocols.
-//!
-use crate::oneio::compressions::get_compression_reader;
 use crate::oneio::{get_protocol, get_writer_raw};
 use crate::OneIoError;
+#[cfg(feature = "http")]
 use reqwest::blocking::Client;
 use std::io::Read;
 
@@ -141,6 +140,8 @@ pub fn get_http_reader(
     path: &str,
     opt_client: Option<Client>,
 ) -> Result<Box<dyn Read + Send>, OneIoError> {
+    use crate::oneio::compressions::get_compression_reader;
+
     let raw_reader: Box<dyn Read + Send> = Box::new(get_http_reader_raw(path, opt_client)?);
     let file_type = *path.split('.').collect::<Vec<&str>>().last().unwrap();
     get_compression_reader(raw_reader, file_type)
@@ -178,6 +179,7 @@ pub fn get_http_reader(
 pub fn download(
     remote_path: &str,
     local_path: &str,
+    // FIXME: the Client is only useful for `http` feature, but `ftp` feature has to depend on it too
     opt_client: Option<Client>,
 ) -> Result<(), OneIoError> {
     match get_protocol(remote_path) {

--- a/src/oneio/utils.rs
+++ b/src/oneio/utils.rs
@@ -1,3 +1,10 @@
+//! Utility functions for file reading and deserialization in OneIO.
+//!
+//! This module provides helper functions to read file contents as strings,
+//! deserialize JSON files into Rust structs, and iterate over lines in files.
+//! These utilities abstract over different file sources and formats,
+//! simplifying common I/O operations for users of the OneIO crate.
+
 use crate::{get_reader, OneIoError};
 use std::io::{BufRead, BufReader, Lines, Read};
 


### PR DESCRIPTION
This pull request introduces changes to the handling of remote IO, compression, and error management in the `oneio` module. The changes include refactoring feature flags, improving modularity by introducing utility functions for compression, and enhancing protocol-specific handling for HTTP, FTP, and S3. Additionally, the build process now validates feature dependencies, ensuring proper configurations.

### Changes to feature flags and dependencies:

* Updated feature flags to distinguish between `http` and `ftp` instead of the generic `remote` flag. This affects error handling in `src/error.rs` and feature-specific module imports in `src/oneio/mod.rs`. 
* Added a build-time check in `build.rs` to ensure that at least one TLS feature (`rustls` or `native-tls`) is enabled when `http`, `ftp`, or `remote` features are used.

### Improvements to compression handling:

* Introduced utility functions `get_compression_reader` and `get_compression_writer` in `src/oneio/compressions/mod.rs` to centralize file compression handling based on file extensions. These replace repetitive match statements in `get_reader` and `get_writer`.
### Enhancements to remote IO:

* Refactored `get_reader_raw` and `get_writer_raw` in `src/oneio/mod.rs` to use the `get_protocol` function for determining the protocol (e.g., HTTP, FTP, S3). This improves modularity and reduces duplication. 
* Removed the `get_reader_raw_remote` function in `src/oneio/remote.rs`, integrating its logic directly into `get_reader_raw` for better maintainability.

### Codebase cleanup and modularity:

* Consolidated protocol-specific logic into separate functions like `get_http_reader_raw` and `get_ftp_reader_raw`, gated by feature flags. These functions are now marked as `pub(crate)` for internal use.
* Removed unused imports and redundant code in `src/oneio/remote.rs` and `src/oneio/mod.rs`.