### PR TITLE
Remove unused rustls_sys dependency and related code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ zstd = { version = "0.13.2", optional = true }
 # feature: digest
 ring = { version = "0.17", optional = true }
 hex = { version = "0.4", optional = true }
-rustls_sys = { package = "rustls", version = "0.23", optional = true }
 
 # feature: json
 serde = { version = "1.0", optional = true }
@@ -92,8 +91,7 @@ native-tls = [
 rustls = [
     "reqwest?/rustls-tls",
     "suppaftp?/rustls",
-    "rust-s3?/sync-rustls-tls",
-    "rustls_sys"
+    "rust-s3?/sync-rustls-tls"
 ]
 
 digest = ["ring", "hex"]

--- a/src/oneio/remote.rs
+++ b/src/oneio/remote.rs
@@ -39,10 +39,6 @@ pub(crate) fn get_http_reader_raw(
             .as_str(),
         "true" | "yes" | "y" | "1"
     );
-    #[cfg(feature = "rustls")]
-    rustls_sys::crypto::aws_lc_rs::default_provider()
-        .install_default()
-        .ok();
 
     let client = match opt_client {
         Some(c) => c,
@@ -278,10 +274,6 @@ pub(crate) fn remote_file_exists(path: &str) -> Result<bool, OneIoError> {
     match get_protocol(path) {
         Some(protocol) => match protocol.as_str() {
             "http" | "https" => {
-                #[cfg(feature = "rustls")]
-                rustls_sys::crypto::aws_lc_rs::default_provider()
-                    .install_default()
-                    .ok();
                 let client = Client::builder()
                     .timeout(std::time::Duration::from_secs(2))
                     .build()?;


### PR DESCRIPTION
Eliminate the unused `rustls_sys` dependency and associated code to streamline the project.