### PR TITLE
Use bzip2 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ suppaftp = { version = "6.0", optional = true }
 
 # feature: compressions
 flate2 = { version = "1", optional = true }
-bzip2 = { version = "0.4.4", optional = true }
+bzip2 = { version = "0.6.0", optional = true }
 lz4 = { version = "1.24", optional = true }
 xz2 = { version = "0.1", optional = true }
 zstd = { version = "0.13.2", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,6 +224,8 @@ oneio::download(
 #### S3-related operations (needs `s3` feature flag)
 
 ```rust,no_run
+#[cfg(feature = "s3")]
+{
 use oneio::s3::*;
 
 // upload to S3
@@ -272,6 +274,7 @@ assert_eq!(
     s3_exists("oneio-test", "test/README___NON_EXISTS.md").unwrap()
 );
 assert_eq!(true, s3_exists("oneio-test", "test/README.md").unwrap());
+}
 ```
 
 # Built with ❤️ by BGPKIT Team


### PR DESCRIPTION
use bzip2 0.6.0. Allows me to target `wasm32-unknown-unknown` with minimal feature set enabled:
```
$ cargo build --release --features=bz,gz --no-default-features --target=wasm32-unknown-unknown
   Compiling oneio v0.18.2 (/Users/tdekock/src/projects/internetmeasurement/oneio)
    Finished `release` profile [optimized] target(s) in 0.50s
```