### PR TITLE
Fix digest command to support remote URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Bug fixes
+- Fixed `digest` command to work with remote URLs (HTTP, HTTPS, FTP, S3)
+
 ## v0.21.0 -- 2026-03-27
 
 ### Breaking changes

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -8,14 +8,24 @@ use ring::digest::{Context, SHA256};
 /// Calculate the SHA256 digest of a file.
 ///
 /// This function takes a path to a file as input and returns the SHA256 digest of the file
-/// as a hexadecimal string.
+/// as a hexadecimal string. Supports both local files and remote URLs (HTTP, HTTPS, FTP, S3).
+///
+/// Note: This function computes the hash of the raw file bytes without any decompression,
+/// even if the file has a compression extension (e.g., `.gz`, `.bz2`).
+///
+/// # Arguments
+///
+/// * `path` - The path to the file. Can be a local file path or a remote URL.
+///
+/// # Returns
+///
+/// Returns the SHA256 digest as a hexadecimal string, or an error if the file cannot be read.
 pub fn get_sha256_digest(path: &str) -> Result<String, OneIoError> {
     let mut context = Context::new(&SHA256);
     let mut buffer = [0; 1024];
 
-    // Open file for reading
-    let file = std::fs::File::open(path)?;
-    let mut reader: Box<dyn std::io::Read + Send> = Box::new(std::io::BufReader::new(file));
+    // Open file for reading (supports both local and remote files, no decompression)
+    let mut reader = crate::OneIo::new()?.get_reader_raw(path)?;
 
     loop {
         let count = reader.read(&mut buffer)?;


### PR DESCRIPTION
## Summary

Fixed the "digest" CLI command and `get_sha256_digest()` library function to work with remote URLs (HTTP, HTTPS, FTP, S3), not just local files.

## Problem

The `oneio digest` command was failing with "No such file or directory" error when provided with a remote URL:

```bash
$ oneio digest https://example.com/file.tar.gz
digest error: IO error: No such file or directory (os error 2)
```

## Root Cause

`get_sha256_digest()` in `src/digest.rs` was using `std::fs::File::open()` which only works with local file paths. It did not support remote URLs that the rest of the oneio library handles.

## Solution

Changed `get_sha256_digest()` to use `OneIo::new()?.get_reader_raw(path)?` instead of `std::fs::File::open(path)`, which:
- Supports both local files and remote URLs
- Uses raw reader without decompression to ensure the hash matches the actual file bytes

## Changes

- `src/digest.rs`: Use `OneIo::get_reader_raw()` instead of `std::fs::File::open()`
- `CHANGELOG.md`: Added entry under "Unreleased" section

## Verification

After the fix:
```bash
$ oneio digest https://github.com/bgpkit/asninfo/releases/download/v0.4.3/asninfo-universal-apple-darwin.tar.gz
9ee71b231224a8162d3a0f9b607b378336262bf38e1433d983d26823e2d3b16b

$ curl -sL https://github.com/bgpkit/asninfo/... | shasum -a 256
9ee71b231224a8162d3a0f9b607b378336262bf38e1433d983d26823e2d3b16b  -
```

Both hashes match, confirming the fix works correctly.

## Related Issue

Fixes #69
