### PR TITLE
fix: remove incorrect Content-Length: 0 from default HTTP headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+- Removed `Content-Length: 0` from default HTTP headers. This header was sent on every request including GETs, where it incorrectly declared a zero-length request body. Some servers and proxies may reject or mishandle requests with an explicit `Content-Length` header on bodyless methods ([#82](https://github.com/bgpkit/oneio/issues/82)).
+
 ## v0.24.2 -- 2026-07-26
 
 ### Fixed

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2,7 +2,7 @@ use crate::OneIoError;
 #[cfg(feature = "http")]
 use reqwest::blocking::Client;
 #[cfg(feature = "http")]
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_LENGTH, USER_AGENT};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, USER_AGENT};
 #[cfg(all(feature = "http", any(feature = "rustls", feature = "native-tls")))]
 use reqwest::Certificate;
 
@@ -180,7 +180,6 @@ impl OneIoBuilder {
 fn default_http_headers() -> HeaderMap {
     let mut headers = HeaderMap::new();
     headers.insert(USER_AGENT, HeaderValue::from_static("oneio"));
-    headers.insert(CONTENT_LENGTH, HeaderValue::from_static("0"));
     #[cfg(feature = "cli")]
     headers.insert(
         reqwest::header::CACHE_CONTROL,


### PR DESCRIPTION
## Summary

`default_http_headers()` unconditionally sets `Content-Length: 0` on every request, including GETs that have no body. The `Content-Length` header describes the request body length — setting it on a bodyless GET is semantically incorrect and can cause some servers/proxies to reject or mishandle the request.

This removes the header entirely, letting reqwest apply its own correct defaults.

Discovered while investigating #82 — that issue turned out to be `read_lines` failing on binary (non-UTF-8) MRT data by design, not an HTTP problem. But the rogue `Content-Length: 0` was a genuine latent bug worth fixing separately.

## Changes
- Removed `CONTENT_LENGTH` header insertion from `default_http_headers()` in `src/builder.rs`
- Removed the now-unused `CONTENT_LENGTH` import
- Updated `CHANGELOG.md`

## Testing
- `cargo fmt --check` ✅
- `cargo clippy --all-features -- -D warnings` ✅
- `cargo clippy --no-default-features` ✅
- `cargo build --all-features` ✅
- `cargo test --all-features` ✅ (9 doctests pass, 2 S3 tests ignored)

Closes #82 (the `Content-Length` aspect; the `read_lines` behavior is by-design — already deprecated since 0.23.0 in favor of `read_lines_lossy` / `read_to_bytes` / `get_reader`).